### PR TITLE
add vscode formatting settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "dart.lineLength": 120,
+  "yaml.format.singleQuote": true
+}


### PR DESCRIPTION
As I use both auto format on save and fairly often format using a keyboard shortcut it makes sense to configure the formatting options.

makes developing using vscode easier.