### PR TITLE
migrate types to built_value

### DIFF
--- a/packages/dynamite/lib/src/openapi_builder.dart
+++ b/packages/dynamite/lib/src/openapi_builder.dart
@@ -65,6 +65,7 @@ class OpenAPIBuilder implements Builder {
         '',
         "import 'package:built_collection/built_collection.dart';",
         "import 'package:built_value/built_value.dart';",
+        "import 'package:built_value/json_object.dart';",
         "import 'package:built_value/serializer.dart';",
         "import 'package:built_value/standard_json_plugin.dart';",
         "import 'package:cookie_jar/cookie_jar.dart';",
@@ -1475,7 +1476,7 @@ TypeResult resolveType(
 }) {
   TypeResult? result;
   if (schema.ref == null && schema.ofs == null && schema.type == null) {
-    return TypeResultBase('dynamic');
+    return TypeResultBase('JsonObject');
   }
   if (schema.ref != null) {
     final name = schema.ref!.split('/').last;
@@ -1716,14 +1717,14 @@ TypeResult resolveType(
             extraJsonSerializableValues: extraJsonSerializableValues,
           );
           result = TypeResultList(
-            'List<${subResult.name}>',
+            'BuiltList<${subResult.name}>',
             subResult,
             fromContentString: fromContentString,
           );
         } else {
           result = TypeResultList(
-            'List',
-            TypeResultBase('dynamic'),
+            'BuiltList<JsonObject>',
+            TypeResultBase('JsonObject'),
           );
         }
         break;
@@ -1732,8 +1733,8 @@ TypeResult resolveType(
           if (schema.additionalProperties != null) {
             if (schema.additionalProperties is EmptySchema) {
               result = TypeResultMap(
-                'Map<String, dynamic>',
-                TypeResultBase('dynamic'),
+                'BuiltMap<String, Object?>',
+                TypeResultBase('JsonObject'),
               );
             } else {
               final subResult = resolveType(
@@ -1744,19 +1745,19 @@ TypeResult resolveType(
                 extraJsonSerializableValues: extraJsonSerializableValues,
               );
               result = TypeResultMap(
-                'Map<String, ${subResult.name}>',
-                TypeResultBase('dynamic'),
+                'BuiltMap<String, ${subResult.name}>',
+                TypeResultBase('JsonObject'),
               );
             }
             break;
           }
-          result = TypeResultBase('dynamic');
+          result = TypeResultBase('JsonObject');
           break;
         }
         if (schema.properties!.isEmpty) {
           result = TypeResultMap(
-            'Map<String, dynamic>',
-            TypeResultBase('dynamic'),
+            'BuiltMap<String, Object?>',
+            TypeResultBase('JsonObject'),
           );
           break;
         }

--- a/packages/dynamite/lib/src/type_result/base.dart
+++ b/packages/dynamite/lib/src/type_result/base.dart
@@ -15,7 +15,12 @@ class TypeResultBase extends TypeResult {
       name == 'String' ? object : '$object.toString()';
 
   @override
-  String deserialize(final String object) => '($object as $name)';
+  String deserialize(final String object, {final bool toBuilder = false}) {
+    if (name == 'JsonObject') {
+      return 'JsonObject($object)';
+    }
+    return '($object as $name)';
+  }
 
   @override
   String decode(final String object) {
@@ -24,6 +29,8 @@ class TypeResultBase extends TypeResult {
         return '($object as String)';
       case 'int':
         return 'int.parse($object as String)';
+      case 'JsonObject':
+        return 'JsonObject($object)';
       default:
         throw Exception('Can not decode "$name" from String');
     }

--- a/packages/dynamite/lib/src/type_result/enum.dart
+++ b/packages/dynamite/lib/src/type_result/enum.dart
@@ -20,7 +20,8 @@ class TypeResultEnum extends TypeResult {
       subType.encode(object);
 
   @override
-  String deserialize(final String object) => '$name.valueOf($object as ${subType.name})';
+  String deserialize(final String object, {final bool toBuilder = false}) =>
+      '$name.valueOf($object as ${subType.name})';
 
   @override
   String decode(final String object) => subType.decode(object);

--- a/packages/dynamite/lib/src/type_result/list.dart
+++ b/packages/dynamite/lib/src/type_result/list.dart
@@ -11,7 +11,7 @@ class TypeResultList extends TypeResult {
   final bool fromContentString;
 
   @override
-  String serialize(final String object) => '$object.map((final e) => ${subType.serialize('e')}).toList()';
+  String serialize(final String object) => '$object.map((final e) => ${subType.serialize('e')})';
 
   @override
   String encode(
@@ -20,7 +20,7 @@ class TypeResultList extends TypeResult {
     final String? mimeType,
   }) {
     if (onlyChildren) {
-      return '$object.map((final e) => ${subType.encode('e', mimeType: mimeType)}).toList()';
+      return '$object.map((final e) => ${subType.encode('e', mimeType: mimeType)})';
     }
 
     switch (mimeType) {
@@ -34,7 +34,8 @@ class TypeResultList extends TypeResult {
   }
 
   @override
-  String deserialize(final String object) => '($object as List).map((final e) => ${subType.deserialize('e')}).toList()';
+  String deserialize(final String object, {final bool toBuilder = false}) =>
+      '$name(($object as List).map((final e) => ${subType.deserialize('e')}))${toBuilder ? '.toBuilder()' : ''}';
 
   @override
   String decode(final String object) => 'json.decode($object as String)';

--- a/packages/dynamite/lib/src/type_result/map.dart
+++ b/packages/dynamite/lib/src/type_result/map.dart
@@ -28,7 +28,8 @@ class TypeResultMap extends TypeResult {
   }
 
   @override
-  String deserialize(final String object) => '($object as Map<String, ${subType.name}>)';
+  String deserialize(final String object, {final bool toBuilder = false}) =>
+      '($object as BuiltMap<String, ${subType.name}>)${toBuilder ? '.toBuilder()' : ''}';
 
   @override
   String decode(final String object) => 'json.decode($object as String)';

--- a/packages/dynamite/lib/src/type_result/object.dart
+++ b/packages/dynamite/lib/src/type_result/object.dart
@@ -4,7 +4,7 @@ class TypeResultObject extends TypeResult {
   TypeResultObject(
     super.name, {
     this.fromContentString = false,
-  });
+  }) : assert(name != 'JsonObject' && name != 'Object' && name != 'dynamic', 'Use TypeResultBase instead');
 
   final bool fromContentString;
 
@@ -33,11 +33,11 @@ class TypeResultObject extends TypeResult {
   }
 
   @override
-  String deserialize(final String object) {
+  String deserialize(final String object, {final bool toBuilder = false}) {
     if (fromContentString) {
-      return '$name.fromJsonString($object as String)';
+      return '$name.fromJsonString($object as String)${toBuilder ? '.toBuilder()' : ''}';
     }
-    return '$name.fromJson($object as Map<String, dynamic>)';
+    return '$name.fromJson($object as Map<String, dynamic>)${toBuilder ? '.toBuilder()' : ''}';
   }
 
   @override

--- a/packages/dynamite/lib/src/type_result/type_result.dart
+++ b/packages/dynamite/lib/src/type_result/type_result.dart
@@ -7,7 +7,7 @@ abstract class TypeResult {
 
   String serialize(final String object);
 
-  String deserialize(final String object);
+  String deserialize(final String object, {final bool toBuilder = false});
 
   String decode(final String object);
 

--- a/packages/nextcloud/lib/src/nextcloud.openapi.dart
+++ b/packages/nextcloud/lib/src/nextcloud.openapi.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
+import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart';
 import 'package:cookie_jar/cookie_jar.dart';
@@ -393,7 +394,7 @@ class NextcloudCoreClient {
     required String itemType,
     required String itemId,
     String? sorter,
-    required List<int> shareTypes,
+    required BuiltList<int> shareTypes,
     int limit = 10,
   }) async {
     var path = '/ocs/v2.php/core/autocomplete/get';
@@ -413,7 +414,7 @@ class NextcloudCoreClient {
     if (sorter != null) {
       queryParameters['sorter'] = sorter;
     }
-    queryParameters['shareTypes[]'] = shareTypes.map((final e) => e).toList().map((final e) => e.toString()).toList();
+    queryParameters['shareTypes[]'] = shareTypes.map((final e) => e).map((final e) => e.toString());
     if (limit != 10) {
       queryParameters['limit'] = limit.toString();
     }
@@ -936,7 +937,7 @@ class NextcloudNotesClient {
 
   final NextcloudClient rootClient;
 
-  Future<List<NextcloudNotesNote>> getNotes({
+  Future<BuiltList<NextcloudNotesNote>> getNotes({
     String? category,
     String exclude = '',
     int pruneBefore = 0,
@@ -980,9 +981,8 @@ class NextcloudNotesClient {
       body,
     );
     if (response.statusCode == 200) {
-      return (json.decode(utf8.decode(response.body) as String) as List)
-          .map((final e) => NextcloudNotesNote.fromJson(e as Map<String, dynamic>))
-          .toList();
+      return BuiltList<NextcloudNotesNote>((json.decode(utf8.decode(response.body) as String) as List)
+          .map((final e) => NextcloudNotesNote.fromJson(e as Map<String, dynamic>)));
     }
     throw NextcloudApiException.fromResponse(response); // coverage:ignore-line
   }
@@ -2208,9 +2208,9 @@ class NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_MetadataAvailable {
           json.decode(data) as Map<String, dynamic>);
   // coverage:ignore-end
 
-  final List<String>? size;
+  final BuiltList<String>? size;
 
-  final List<String>? gps;
+  final BuiltList<String>? gps;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() =>
@@ -2275,7 +2275,7 @@ class NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Files {
   final bool? bigfilechunking;
 
   @JsonKey(name: 'blacklisted_files')
-  final List<String>? blacklistedFiles;
+  final BuiltList<String>? blacklistedFiles;
 
   final NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Files_DirectEditing? directEditing;
 
@@ -2307,7 +2307,7 @@ class NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Activity {
           json.decode(data) as Map<String, dynamic>);
   // coverage:ignore-end
 
-  final List<String>? apiv2;
+  final BuiltList<String>? apiv2;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_ActivityToJson(this);
@@ -2395,9 +2395,9 @@ class NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Circles_Circle_Const
           json.decode(data) as Map<String, dynamic>);
   // coverage:ignore-end
 
-  final dynamic core;
+  final JsonObject? core;
 
-  final dynamic extra;
+  final JsonObject? extra;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() =>
@@ -2427,7 +2427,7 @@ class NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Circles_Circle_Const
           json.decode(data) as Map<String, dynamic>);
   // coverage:ignore-end
 
-  final dynamic flags;
+  final JsonObject? flags;
 
   final NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Circles_Circle_Constants_Source? source;
 
@@ -2458,9 +2458,9 @@ class NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Circles_Circle_Confi
           json.decode(data) as Map<String, dynamic>);
   // coverage:ignore-end
 
-  final List<int>? coreFlags;
+  final BuiltList<int>? coreFlags;
 
-  final List<int>? systemFlags;
+  final BuiltList<int>? systemFlags;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() =>
@@ -2515,7 +2515,7 @@ class NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Circles_Member_Const
           json.decode(data) as Map<String, dynamic>);
   // coverage:ignore-end
 
-  final dynamic level;
+  final JsonObject? level;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() =>
@@ -2545,7 +2545,7 @@ class NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Circles_Member {
 
   final NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Circles_Member_Constants? constants;
 
-  final dynamic type;
+  final JsonObject? type;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Circles_MemberToJson(this);
@@ -2640,7 +2640,7 @@ class NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Ocm_ResourceTypes {
 
   final String? name;
 
-  final List<String>? shareTypes;
+  final BuiltList<String>? shareTypes;
 
   final NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Ocm_ResourceTypes_Protocols? protocols;
 
@@ -2677,7 +2677,7 @@ class NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Ocm {
 
   final String? endPoint;
 
-  final List<NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Ocm_ResourceTypes>? resourceTypes;
+  final BuiltList<NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Ocm_ResourceTypes>? resourceTypes;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_OcmToJson(this);
@@ -3350,7 +3350,7 @@ class NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Notes {
   // coverage:ignore-end
 
   @JsonKey(name: 'api_version')
-  final List<String>? apiVersion;
+  final BuiltList<String>? apiVersion;
 
   final String? version;
 
@@ -3381,12 +3381,12 @@ class NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_Notifications {
   // coverage:ignore-end
 
   @JsonKey(name: 'ocs-endpoints')
-  final List<String>? ocsEndpoints;
+  final BuiltList<String>? ocsEndpoints;
 
-  final List<String>? push;
+  final BuiltList<String>? push;
 
   @JsonKey(name: 'admin-notifications')
-  final List<String>? adminNotifications;
+  final BuiltList<String>? adminNotifications;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudCoreServerCapabilities_Ocs_Data_Capabilities_NotificationsToJson(this);
@@ -3895,7 +3895,7 @@ class NextcloudCoreNavigationApps_Ocs {
 
   final NextcloudOCSMeta meta;
 
-  final List<NextcloudCoreNavigationApps_Ocs_Data> data;
+  final BuiltList<NextcloudCoreNavigationApps_Ocs_Data> data;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudCoreNavigationApps_OcsToJson(this);
@@ -4013,23 +4013,23 @@ class NextcloudCoreLoginFlowResult {
 class NextcloudCoreAutocompleteResult_Ocs_Data_Status {
   NextcloudCoreAutocompleteResult_Ocs_Data_Status(
     this._data, {
-    this.listDynamic,
+    this.builtListJsonObject,
     this.string,
   });
 
   factory NextcloudCoreAutocompleteResult_Ocs_Data_Status.fromJson(dynamic data) {
-    List<dynamic>? listDynamic;
+    BuiltList<JsonObject>? builtListJsonObject;
     String? string;
     try {
-      listDynamic = (data as List).map((final e) => (e as dynamic)).toList();
+      builtListJsonObject = BuiltList<JsonObject>((data as List).map((final e) => JsonObject(e)));
     } catch (_) {}
     try {
       string = (data as String);
     } catch (_) {}
-    assert([listDynamic, string].where((final x) => x != null).length >= 1, 'Need oneOf for $data');
+    assert([builtListJsonObject, string].where((final x) => x != null).length >= 1, 'Need oneOf for $data');
     return NextcloudCoreAutocompleteResult_Ocs_Data_Status(
       data,
-      listDynamic: listDynamic,
+      builtListJsonObject: builtListJsonObject,
       string: string,
     );
   }
@@ -4041,7 +4041,7 @@ class NextcloudCoreAutocompleteResult_Ocs_Data_Status {
 
   final dynamic _data;
 
-  final List<dynamic>? listDynamic;
+  final BuiltList<JsonObject>? builtListJsonObject;
 
   final String? string;
 
@@ -4115,7 +4115,7 @@ class NextcloudCoreAutocompleteResult_Ocs {
 
   final NextcloudOCSMeta meta;
 
-  final List<NextcloudCoreAutocompleteResult_Ocs_Data> data;
+  final BuiltList<NextcloudCoreAutocompleteResult_Ocs_Data> data;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudCoreAutocompleteResult_OcsToJson(this);
@@ -4161,7 +4161,7 @@ class NextcloudNewsSupportedAPIVersions {
       NextcloudNewsSupportedAPIVersions.fromJson(json.decode(data) as Map<String, dynamic>);
   // coverage:ignore-end
 
-  final List<String>? apiLevels;
+  final BuiltList<String>? apiLevels;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudNewsSupportedAPIVersionsToJson(this);
@@ -4301,7 +4301,7 @@ class NextcloudNewsFeed {
 
   final String? lastUpdateError;
 
-  final List<NextcloudNewsArticle> items;
+  final BuiltList<NextcloudNewsArticle> items;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudNewsFeedToJson(this);
@@ -4334,7 +4334,7 @@ class NextcloudNewsFolder {
   final bool opened;
 
   /// This seems to be broken. In testing it is always empty
-  final List<NextcloudNewsFeed> feeds;
+  final BuiltList<NextcloudNewsFeed> feeds;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudNewsFolderToJson(this);
@@ -4355,7 +4355,7 @@ class NextcloudNewsListFolders {
       NextcloudNewsListFolders.fromJson(json.decode(data) as Map<String, dynamic>);
   // coverage:ignore-end
 
-  final List<NextcloudNewsFolder> folders;
+  final BuiltList<NextcloudNewsFolder> folders;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudNewsListFoldersToJson(this);
@@ -4384,7 +4384,7 @@ class NextcloudNewsListFeeds {
 
   final int? newestItemId;
 
-  final List<NextcloudNewsFeed> feeds;
+  final BuiltList<NextcloudNewsFeed> feeds;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudNewsListFeedsToJson(this);
@@ -4405,7 +4405,7 @@ class NextcloudNewsListArticles {
       NextcloudNewsListArticles.fromJson(json.decode(data) as Map<String, dynamic>);
   // coverage:ignore-end
 
-  final List<NextcloudNewsArticle> items;
+  final BuiltList<NextcloudNewsArticle> items;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudNewsListArticlesToJson(this);
@@ -4593,15 +4593,15 @@ class NextcloudNotificationsNotification {
 
   final String subjectRich;
 
-  final dynamic subjectRichParameters;
+  final JsonObject subjectRichParameters;
 
   final String messageRich;
 
-  final dynamic messageRichParameters;
+  final JsonObject messageRichParameters;
 
   final String icon;
 
-  final List<NextcloudNotificationsNotificationAction> actions;
+  final BuiltList<NextcloudNotificationsNotificationAction> actions;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudNotificationsNotificationToJson(this);
@@ -4629,7 +4629,7 @@ class NextcloudNotificationsListNotifications_Ocs {
 
   final NextcloudOCSMeta meta;
 
-  final List<NextcloudNotificationsNotification> data;
+  final BuiltList<NextcloudNotificationsNotification> data;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudNotificationsListNotifications_OcsToJson(this);
@@ -4730,7 +4730,7 @@ class NextcloudEmptyOCS_Ocs {
 
   final NextcloudOCSMeta meta;
 
-  final List data;
+  final BuiltList<JsonObject> data;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudEmptyOCS_OcsToJson(this);
@@ -4974,7 +4974,7 @@ class NextcloudProvisioningApiUserDetails {
 
   final String backend;
 
-  final List<String> subadmin;
+  final BuiltList<String> subadmin;
 
   final NextcloudProvisioningApiUserDetails_Quota quota;
 
@@ -4985,10 +4985,10 @@ class NextcloudProvisioningApiUserDetails {
   final String emailScope;
 
   @JsonKey(name: 'additional_mail')
-  final List<String> additionalMail;
+  final BuiltList<String> additionalMail;
 
   @JsonKey(name: 'additional_mailScope')
-  final List<String> additionalMailScope;
+  final BuiltList<String> additionalMailScope;
 
   final String? displayname;
 
@@ -5036,7 +5036,7 @@ class NextcloudProvisioningApiUserDetails {
 
   final String fediverseScope;
 
-  final List<String> groups;
+  final BuiltList<String> groups;
 
   final String language;
 
@@ -5430,7 +5430,7 @@ class NextcloudUnifiedPushProviderGatewayMatrixResponse200ApplicationJson {
           json.decode(data) as Map<String, dynamic>);
   // coverage:ignore-end
 
-  final List<String> rejected;
+  final BuiltList<String> rejected;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudUnifiedPushProviderGatewayMatrixResponse200ApplicationJsonToJson(this);
@@ -5652,7 +5652,7 @@ class NextcloudUserStatusGetPublicStatuses_Ocs {
 
   final NextcloudOCSMeta meta;
 
-  final List<NextcloudUserStatusPublicStatus> data;
+  final BuiltList<NextcloudUserStatusPublicStatus> data;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudUserStatusGetPublicStatuses_OcsToJson(this);
@@ -5687,23 +5687,24 @@ class NextcloudUserStatusGetPublicStatuses {
 class NextcloudUserStatusGetPublicStatus_Ocs_Data {
   NextcloudUserStatusGetPublicStatus_Ocs_Data(
     this._data, {
-    this.listDynamic,
+    this.builtListJsonObject,
     this.userStatusPublicStatus,
   });
 
   factory NextcloudUserStatusGetPublicStatus_Ocs_Data.fromJson(dynamic data) {
-    List<dynamic>? listDynamic;
+    BuiltList<JsonObject>? builtListJsonObject;
     NextcloudUserStatusPublicStatus? userStatusPublicStatus;
     try {
-      listDynamic = (data as List).map((final e) => (e as dynamic)).toList();
+      builtListJsonObject = BuiltList<JsonObject>((data as List).map((final e) => JsonObject(e)));
     } catch (_) {}
     try {
       userStatusPublicStatus = NextcloudUserStatusPublicStatus.fromJson(data as Map<String, dynamic>);
     } catch (_) {}
-    assert([listDynamic, userStatusPublicStatus].where((final x) => x != null).length >= 1, 'Need oneOf for $data');
+    assert([builtListJsonObject, userStatusPublicStatus].where((final x) => x != null).length >= 1,
+        'Need oneOf for $data');
     return NextcloudUserStatusGetPublicStatus_Ocs_Data(
       data,
-      listDynamic: listDynamic,
+      builtListJsonObject: builtListJsonObject,
       userStatusPublicStatus: userStatusPublicStatus,
     );
   }
@@ -5715,7 +5716,7 @@ class NextcloudUserStatusGetPublicStatus_Ocs_Data {
 
   final dynamic _data;
 
-  final List<dynamic>? listDynamic;
+  final BuiltList<JsonObject>? builtListJsonObject;
 
   final NextcloudUserStatusPublicStatus? userStatusPublicStatus;
 
@@ -5869,23 +5870,23 @@ class NextcloudUserStatusStatus {
 class NextcloudUserStatusGetStatus_Ocs_Data {
   NextcloudUserStatusGetStatus_Ocs_Data(
     this._data, {
-    this.listDynamic,
+    this.builtListJsonObject,
     this.userStatusStatus,
   });
 
   factory NextcloudUserStatusGetStatus_Ocs_Data.fromJson(dynamic data) {
-    List<dynamic>? listDynamic;
+    BuiltList<JsonObject>? builtListJsonObject;
     NextcloudUserStatusStatus? userStatusStatus;
     try {
-      listDynamic = (data as List).map((final e) => (e as dynamic)).toList();
+      builtListJsonObject = BuiltList<JsonObject>((data as List).map((final e) => JsonObject(e)));
     } catch (_) {}
     try {
       userStatusStatus = NextcloudUserStatusStatus.fromJson(data as Map<String, dynamic>);
     } catch (_) {}
-    assert([listDynamic, userStatusStatus].where((final x) => x != null).length >= 1, 'Need oneOf for $data');
+    assert([builtListJsonObject, userStatusStatus].where((final x) => x != null).length >= 1, 'Need oneOf for $data');
     return NextcloudUserStatusGetStatus_Ocs_Data(
       data,
-      listDynamic: listDynamic,
+      builtListJsonObject: builtListJsonObject,
       userStatusStatus: userStatusStatus,
     );
   }
@@ -5897,7 +5898,7 @@ class NextcloudUserStatusGetStatus_Ocs_Data {
 
   final dynamic _data;
 
-  final List<dynamic>? listDynamic;
+  final BuiltList<JsonObject>? builtListJsonObject;
 
   final NextcloudUserStatusStatus? userStatusStatus;
 
@@ -6056,7 +6057,7 @@ class NextcloudUserStatusPredefinedStatuses_Ocs {
 
   final NextcloudOCSMeta meta;
 
-  final List<NextcloudUserStatusPredefinedStatus> data;
+  final BuiltList<NextcloudUserStatusPredefinedStatus> data;
 
   // coverage:ignore-start
   Map<String, dynamic> toJson() => _$NextcloudUserStatusPredefinedStatuses_OcsToJson(this);

--- a/packages/nextcloud/test/core.dart
+++ b/packages/nextcloud/test/core.dart
@@ -1,3 +1,4 @@
+import 'package:built_collection/built_collection.dart';
 import 'package:nextcloud/nextcloud.dart';
 import 'package:test/test.dart';
 
@@ -67,10 +68,10 @@ Future run(final DockerImage image) async {
         search: '',
         itemType: 'call',
         itemId: 'new',
-        shareTypes: [
+        shareTypes: BuiltList([
           ShareType.user.code,
           ShareType.group.code,
-        ],
+        ]),
       );
       expect(response.ocs.data, hasLength(3));
 

--- a/packages/nextcloud/test/notifications.dart
+++ b/packages/nextcloud/test/notifications.dart
@@ -51,9 +51,9 @@ Future run(final DockerImage image) async {
       expect(response.ocs.data[0].message, '456');
       expect(response.ocs.data[0].link, '');
       expect(response.ocs.data[0].subjectRich, '');
-      expect(response.ocs.data[0].subjectRichParameters, isEmpty);
+      expect(response.ocs.data[0].subjectRichParameters.asList, isEmpty);
       expect(response.ocs.data[0].messageRich, '');
-      expect(response.ocs.data[0].messageRichParameters, isEmpty);
+      expect(response.ocs.data[0].messageRichParameters.asList, isEmpty);
       expect(response.ocs.data[0].icon, isNotEmpty);
       expect(response.ocs.data[0].actions, hasLength(0));
     });
@@ -73,9 +73,9 @@ Future run(final DockerImage image) async {
       expect(response.ocs.data.message, '456');
       expect(response.ocs.data.link, '');
       expect(response.ocs.data.subjectRich, '');
-      expect(response.ocs.data.subjectRichParameters, isEmpty);
+      expect(response.ocs.data.subjectRichParameters.asList, isEmpty);
       expect(response.ocs.data.messageRich, '');
-      expect(response.ocs.data.messageRichParameters, isEmpty);
+      expect(response.ocs.data.messageRichParameters.asList, isEmpty);
       expect(response.ocs.data.icon, isNotEmpty);
       expect(response.ocs.data.actions, hasLength(0));
     });


### PR DESCRIPTION
built_value works on types and does not know the concept of fields (foreshadowing the contentString PR) thus we can't use dynamic. Fortunately it provides a cool JsonObject class.

It also migrates to `BuiltMap` and `BuiltList`.

We need the `toBuilder` stuff for when we generate our custom serializers mostly someOfs. 

I'm not 100% sure what the serialize and deserialize methods are used for so I might need to also adjust:
https://github.com/provokateurin/nextcloud-neon/blob/4daeda84bdb503167bf655e9c02091129e3d99da/packages/dynamite/lib/src/type_result/base.dart#L7
for the JsonObject case