### PR TITLE
sortbox: improve performance

### DIFF
--- a/packages/sort_box/.gitignore
+++ b/packages/sort_box/.gitignore
@@ -28,3 +28,5 @@ migrate_working_dir/
 .dart_tool/
 .packages
 build/
+
+coverage/


### PR DESCRIPTION
https://github.com/Leptopoda/nextcloud-neon/blob/0cdd0c15da37cf30eb1dec556b31fd9e5f3730ea/packages/sort_box/lib/sort_box.dart#L24

Ideas for a better variable name are welcome :)

https://github.com/Leptopoda/nextcloud-neon/blob/0cdd0c15da37cf30eb1dec556b31fd9e5f3730ea/packages/sort_box/lib/sort_box.dart#L9

should we make the comparablegetter it's own typedef?
I don't think it's worth it but it went through my head so just asking.

---

I removed  `preventSecondarySort` from the api as I think it was only to make the recursiveness working but we can obviously still support it.