### PR TITLE
Always display error messages

### DIFF
--- a/packages/neon/neon/lib/src/pages/home.dart
+++ b/packages/neon/neon/lib/src/pages/home.dart
@@ -482,10 +482,10 @@ class _HomePageState extends State<HomePage> {
                                                 const SizedBox(
                                                   width: 8,
                                                 ),
-                                                Icon(
-                                                  Icons.error_outline,
-                                                  size: 30,
-                                                  color: Theme.of(context).colorScheme.onPrimary,
+                                                NeonException(
+                                                  appImplementations.error,
+                                                  onRetry: _appsBloc.refresh,
+                                                  onlyIcon: true,
                                                 ),
                                               ],
                                               if (appImplementations.loading) ...[
@@ -563,10 +563,6 @@ class _HomePageState extends State<HomePage> {
                                         Expanded(
                                           child: Column(
                                             children: [
-                                              NeonException(
-                                                appImplementations.error,
-                                                onRetry: _appsBloc.refresh,
-                                              ),
                                               if (appImplementations.data != null) ...[
                                                 if (appImplementations.data!.isEmpty) ...[
                                                   Expanded(

--- a/packages/neon/neon/lib/src/utils/request_manager.dart
+++ b/packages/neon/neon/lib/src/utils/request_manager.dart
@@ -85,6 +85,7 @@ class RequestManager {
       deserialize,
       emitEmptyCache,
       true,
+      null,
     );
 
     try {
@@ -117,6 +118,7 @@ class RequestManager {
         deserialize,
         emitEmptyCache,
         false,
+        e,
       ))) {
         subject.add(Result.error(e));
       }
@@ -130,6 +132,7 @@ class RequestManager {
     final R Function(String) deserialize,
     final bool emitEmptyCache,
     final bool loading,
+    final Object? error,
   ) async {
     T? cached;
     try {
@@ -144,7 +147,7 @@ class RequestManager {
       subject.add(
         Result(
           cached,
-          null,
+          error,
           loading: loading,
           cached: true,
         ),

--- a/packages/neon/neon/lib/src/widgets/account_avatar.dart
+++ b/packages/neon/neon/lib/src/widgets/account_avatar.dart
@@ -14,6 +14,7 @@ class NeonAccountAvatar extends StatelessWidget {
   Widget build(final BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final size = (kAvatarSize * MediaQuery.of(context).devicePixelRatio).toInt();
+    final userStatusBloc = Provider.of<AccountsBloc>(context, listen: false).getUserStatusBloc(account);
     return Stack(
       alignment: Alignment.center,
       children: [
@@ -40,7 +41,7 @@ class NeonAccountAvatar extends StatelessWidget {
           ),
         ),
         ResultBuilder<UserStatusBloc, NextcloudUserStatusStatus?>(
-          stream: Provider.of<AccountsBloc>(context, listen: false).getUserStatusBloc(account).userStatus,
+          stream: userStatusBloc.userStatus,
           builder: (final context, final userStatus) {
             final hasEmoji = userStatus.data?.icon != null;
             final factor = hasEmoji ? 2 : 3;
@@ -66,10 +67,11 @@ class NeonAccountAvatar extends StatelessWidget {
                       : userStatus.error != null &&
                               (userStatus.error is! NextcloudApiException ||
                                   (userStatus.error! as NextcloudApiException).statusCode != 404)
-                          ? Icon(
-                              Icons.error_outline,
-                              size: kAvatarSize / factor,
-                              color: Colors.red,
+                          ? NeonException(
+                              userStatus.error,
+                              onRetry: userStatusBloc.refresh,
+                              onlyIcon: true,
+                              iconSize: kAvatarSize / factor,
                             )
                           : hasEmoji
                               ? Text(

--- a/packages/neon/neon/lib/src/widgets/cached_api_image.dart
+++ b/packages/neon/neon/lib/src/widgets/cached_api_image.dart
@@ -15,7 +15,7 @@ class NeonCachedApiImage extends NeonCachedImage {
     super.iconColor,
     super.key,
   }) : super(
-          future: () async {
+          getImageFile: () async {
             final realKey = '${account.id}-$cacheKey';
             final cacheFile = await _cacheManager.getFileFromCache(realKey);
             if (cacheFile != null && cacheFile.validTill.isAfter(DateTime.now())) {
@@ -28,6 +28,6 @@ class NeonCachedApiImage extends NeonCachedImage {
               maxAge: const Duration(days: 7),
               eTag: etag,
             );
-          }(),
+          },
         );
 }

--- a/packages/neon/neon/lib/src/widgets/cached_url_image.dart
+++ b/packages/neon/neon/lib/src/widgets/cached_url_image.dart
@@ -10,7 +10,7 @@ class NeonCachedUrlImage extends NeonCachedImage {
     super.iconColor,
     super.key,
   }) : super(
-          future: _cacheManager.getSingleFile(url),
+          getImageFile: () => _cacheManager.getSingleFile(url),
           isSvgHint: Uri.parse(url).path.endsWith('.svg'),
         );
 }

--- a/packages/neon/neon/lib/src/widgets/exception.dart
+++ b/packages/neon/neon/lib/src/widgets/exception.dart
@@ -5,14 +5,16 @@ class NeonException extends StatelessWidget {
     this.exception, {
     required this.onRetry,
     this.onlyIcon = false,
-    this.iconSize = 30,
+    this.iconSize,
+    this.color,
     super.key,
   });
 
   final dynamic exception;
   final Function() onRetry;
   final bool onlyIcon;
-  final double iconSize;
+  final double? iconSize;
+  final Color? color;
 
   static void showSnackbar(final BuildContext context, final dynamic exception) {
     final details = _getExceptionDetails(context, exception);
@@ -41,8 +43,8 @@ class NeonException extends StatelessWidget {
 
               final errorIcon = Icon(
                 Icons.error_outline,
-                size: iconSize,
-                color: Colors.red,
+                size: iconSize ?? 30,
+                color: color ?? Colors.red,
               );
 
               if (onlyIcon) {
@@ -71,8 +73,8 @@ class NeonException extends StatelessWidget {
                       Flexible(
                         child: Text(
                           details.text,
-                          style: const TextStyle(
-                            color: Colors.red,
+                          style: TextStyle(
+                            color: color ?? Colors.red,
                           ),
                         ),
                       ),


### PR DESCRIPTION
Previously error messages weren't shown if a cached version was available. This could lead to user confusion.