### PR TITLE
neon: fix NC icon color of QuickBar

### DIFF
--- a/packages/neon/neon/lib/src/pages/home.dart
+++ b/packages/neon/neon/lib/src/pages/home.dart
@@ -460,6 +460,7 @@ class _HomePageState extends State<HomePage> {
                                               child: capabilities.data?.capabilities.theming?.logo != null
                                                   ? NeonCachedUrlImage(
                                                       url: capabilities.data!.capabilities.theming!.logo!,
+                                                      svgColor: Theme.of(context).iconTheme.color,
                                                     )
                                                   : null,
                                             )


### PR DESCRIPTION
Fixes the icon color of the NC logo in LightMode
Before:
![Screenshot_20230505_230700](https://user-images.githubusercontent.com/25266387/236572951-13bfac58-7c2b-42fc-aaa0-6d4e8eeb93ab.png)
After:
![Screenshot_20230505_233621](https://user-images.githubusercontent.com/25266387/236572953-4c4b1c4a-ea4f-4388-8c37-b8b442658ccc.png)

Yes the notch is clipping a lot of the app and I wanted to fix this while discovering this easy one. Note that the clipping fix isn't in here yet as it is also present on a lot of other screens and I'll go through them one by one.
