### PR TITLE
Stop pinning intl

### DIFF
--- a/packages/neon/neon/pubspec.yaml
+++ b/packages/neon/neon/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   flutter_native_splash: ^2.2.0+1
   flutter_svg: ^1.0.3
   http: ^0.13.4
-  intl: ^0.17.0
+  intl: any
   json_annotation: ^4.7.0
   material_design_icons_flutter: ^6.0.7096
   nextcloud:

--- a/packages/nextcloud/pubspec.yaml
+++ b/packages/nextcloud/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   cookie_jar: ^3.0.1
   crypto: ^3.0.2
   crypton: ^2.0.5
-  intl: ^0.17.0
+  intl: any
   json_annotation: ^4.7.0
   version: ^3.0.2
   xml: ^6.1.0


### PR DESCRIPTION
This broke CI when the new flutter version was released (due to missing version pinning for flutter in CI) and it also makes upgrading annoying, so we just drop it.