### PR TITLE
neon, nextcloud, app: don't use local dependencies

### DIFF
--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -146,7 +146,7 @@ packages:
     source: hosted
     version: "0.7.8"
   dynamite_runtime:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "../dynamite/dynamite_runtime"
       relative: true
@@ -177,7 +177,7 @@ packages:
     source: hosted
     version: "6.1.4"
   file_icons:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "../file_icons"
       relative: true
@@ -534,7 +534,7 @@ packages:
     source: hosted
     version: "1.0.0"
   nextcloud:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "../nextcloud"
       relative: true
@@ -790,7 +790,7 @@ packages:
     source: hosted
     version: "0.1.6"
   settings:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "../settings"
       relative: true
@@ -882,7 +882,7 @@ packages:
     source: sdk
     version: "0.0.99"
   sort_box:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "../sort_box"
       relative: true

--- a/packages/app/pubspec.yaml
+++ b/packages/app/pubspec.yaml
@@ -11,15 +11,25 @@ dependencies:
     sdk: flutter
   flutter_native_splash: ^2.2.19
   neon:
-    path: ../neon/neon
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/neon/neon
   neon_files:
-    path: ../neon/neon_files
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/neon/neon_files
   neon_news:
-    path: ../neon/neon_news
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/neon/neon_news
   neon_notes:
-    path: ../neon/neon_notes
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/neon/neon_notes
   neon_notifications:
-    path: ../neon/neon_notifications
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/neon/neon_notifications
   shared_preferences: ^2.1.1
 
 dev_dependencies:
@@ -34,6 +44,26 @@ dev_dependencies:
       ref: 0b2ee0d
 
 dependency_overrides:
+  dynamite_runtime:
+    path: ../dynamite/dynamite_runtime
+  file_icons:
+    path: ../file_icons
+  neon:
+    path: ../neon/neon
+  neon_files:
+    path: ../neon/neon_files
+  neon_news:
+    path: ../neon/neon_news
+  neon_notes:
+    path: ../neon/neon_notes
+  neon_notifications:
+    path: ../neon/neon_notifications
+  nextcloud:
+    path: ../nextcloud
+  settings:
+    path: ../settings
+  sort_box:
+    path: ../sort_box
   wakelock_windows: # TODO: https://github.com/creativecreatorormaybenot/wakelock/pull/195
     git:
       url: https://github.com/creativecreatorormaybenot/wakelock

--- a/packages/neon/neon/pubspec.yaml
+++ b/packages/neon/neon/pubspec.yaml
@@ -26,7 +26,9 @@ dependencies:
   json_annotation: ^4.8.1
   material_design_icons_flutter: ^6.0.7096
   nextcloud:
-    path: ../../nextcloud
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/nextcloud
   package_info_plus: ^4.0.0
   path: ^1.8.3
   path_provider: ^2.0.15
@@ -35,10 +37,14 @@ dependencies:
   quick_actions: ^1.0.3
   rxdart: ^0.27.7
   settings:
-    path: ../../settings
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/settings
   shared_preferences: ^2.1.1
   sort_box:
-    path: ../../sort_box
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/sort_box
   sqflite: ^2.2.8+2
   sqflite_common_ffi: ^2.2.5
   tray_manager: ^0.2.0
@@ -58,6 +64,14 @@ dev_dependencies:
       ref: 0b2ee0d
 
 dependency_overrides:
+  dynamite_runtime:
+    path: ../../dynamite/dynamite_runtime
+  nextcloud:
+    path: ../../nextcloud
+  settings:
+    path: ../../settings
+  sort_box:
+    path: ../../sort_box
   wakelock_windows: # TODO: https://github.com/creativecreatorormaybenot/wakelock/pull/195
     git:
       url: https://github.com/creativecreatorormaybenot/wakelock

--- a/packages/neon/neon_files/pubspec.yaml
+++ b/packages/neon/neon_files/pubspec.yaml
@@ -9,7 +9,9 @@ environment:
 dependencies:
   collection: ^1.17.0
   file_icons:
-    path: ../../file_icons
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/file_icons
   file_picker: ^5.3.0
   filesize: ^2.0.1
   flutter:
@@ -18,24 +20,47 @@ dependencies:
   intersperse: ^2.0.0
   material_design_icons_flutter: ^6.0.7096
   neon:
-    path: ../neon
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/neon/neon
   nextcloud:
-    path: ../../nextcloud
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/nextcloud
   open_file: ^3.3.1
   path: ^1.8.3
   provider: ^6.0.5
   queue: ^3.1.0+2
   rxdart: ^0.27.7
   settings:
-    path: ../../settings
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/settings
+  share_plus: ^7.0.0
   sort_box:
-    path: ../../sort_box
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/sort_box
 
 dev_dependencies:
   nit_picking:
     git:
       url: https://github.com/stack11/dart_nit_picking
       ref: 0b2ee0d
+
+dependency_overrides:
+  dynamite_runtime:
+    path: ../../dynamite/dynamite_runtime
+  file_icons:
+    path: ../../file_icons
+  neon:
+    path: ../neon
+  nextcloud:
+    path: ../../nextcloud
+  settings:
+    path: ../../settings
+  sort_box:
+    path: ../../sort_box
 
 flutter:
   uses-material-design: true

--- a/packages/neon/neon_news/pubspec.yaml
+++ b/packages/neon/neon_news/pubspec.yaml
@@ -13,16 +13,24 @@ dependencies:
   html: ^0.15.3
   material_design_icons_flutter: ^6.0.7096
   neon:
-    path: ../neon
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/neon/neon
   nextcloud:
-    path: ../../nextcloud
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/nextcloud
   provider: ^6.0.5
   rxdart: ^0.27.7
   settings:
-    path: ../../settings
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/settings
   share_plus: ^7.0.0
   sort_box:
-    path: ../../sort_box
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/sort_box
   url_launcher: ^6.1.11
   wakelock: ^0.6.2
   webview_flutter: ^4.2.0
@@ -34,6 +42,16 @@ dev_dependencies:
       ref: 0b2ee0d
 
 dependency_overrides:
+  dynamite_runtime:
+    path: ../../dynamite/dynamite_runtime
+  neon:
+    path: ../neon
+  nextcloud:
+    path: ../../nextcloud
+  settings:
+    path: ../../settings
+  sort_box:
+    path: ../../sort_box
   wakelock_windows: # TODO: https://github.com/creativecreatorormaybenot/wakelock/pull/195
     git:
       url: https://github.com/creativecreatorormaybenot/wakelock

--- a/packages/neon/neon_notes/pubspec.yaml
+++ b/packages/neon/neon_notes/pubspec.yaml
@@ -13,16 +13,24 @@ dependencies:
   flutter_markdown: ^0.6.14
   material_design_icons_flutter: ^6.0.7096
   neon:
-    path: ../neon
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/neon/neon
   nextcloud:
-    path: ../../nextcloud
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/nextcloud
   provider: ^6.0.5
   queue: ^3.1.0+2
   rxdart: ^0.27.7
   settings:
-    path: ../../settings
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/settings
   sort_box:
-    path: ../../sort_box
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/sort_box
   url_launcher: ^6.1.11
   wakelock: ^0.6.2
 
@@ -33,6 +41,16 @@ dev_dependencies:
       ref: 0b2ee0d
 
 dependency_overrides:
+  dynamite_runtime:
+    path: ../../dynamite/dynamite_runtime
+  neon:
+    path: ../neon
+  nextcloud:
+    path: ../../nextcloud
+  settings:
+    path: ../../settings
+  sort_box:
+    path: ../../sort_box
   wakelock_windows: # TODO: https://github.com/creativecreatorormaybenot/wakelock/pull/195
     git:
       url: https://github.com/creativecreatorormaybenot/wakelock

--- a/packages/neon/neon_notifications/pubspec.yaml
+++ b/packages/neon/neon_notifications/pubspec.yaml
@@ -11,9 +11,13 @@ dependencies:
     sdk: flutter
   material_design_icons_flutter: ^6.0.7096
   neon:
-    path: ../neon
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/neon/neon
   nextcloud:
-    path: ../../nextcloud
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/nextcloud
   provider: ^6.0.5
   rxdart: ^0.27.7
 
@@ -22,6 +26,18 @@ dev_dependencies:
     git:
       url: https://github.com/stack11/dart_nit_picking
       ref: 0b2ee0d
+
+dependency_overrides:
+  dynamite_runtime:
+    path: ../../dynamite/dynamite_runtime
+  neon:
+    path: ../neon
+  nextcloud:
+    path: ../../nextcloud
+  settings:
+    path: ../../settings
+  sort_box:
+    path: ../../sort_box
 
 flutter:
   uses-material-design: true

--- a/packages/nextcloud/README.md
+++ b/packages/nextcloud/README.md
@@ -15,6 +15,13 @@ dependencies:
       url: https://github.com/provokateurin/nextcloud-neon
       path: packages/nextcloud
       ref: $COMMIT
+
+dependency_overrides:
+  dynamite_runtime:
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/dynamite/dynamite_runtime
+      ref: $COMMIT
 ```
 You can either remove the `ref` or use a commit hash. It's not recommended to remove it, because then the version will be updated very often.
 

--- a/packages/nextcloud/pubspec.yaml
+++ b/packages/nextcloud/pubspec.yaml
@@ -12,7 +12,9 @@ dependencies:
   crypto: ^3.0.3
   crypton: ^2.0.5
   dynamite_runtime:
-    path: ../dynamite/dynamite_runtime
+    git:
+      url: https://github.com/provokateurin/nextcloud-neon
+      path: packages/dynamite/dynamite_runtime
   intl: ^0.18.0
   universal_io: ^2.2.0
   version: ^3.0.2
@@ -32,3 +34,7 @@ dev_dependencies:
   process_run: ^0.13.0
   test: ^1.24.2
   xml_serializable: ^2.2.2
+
+dependency_overrides:
+  dynamite_runtime:
+    path: ../dynamite/dynamite_runtime


### PR DESCRIPTION
fixes: #326 

The only downside of this is that we don't pin dependencies. This means someone could use the nextcloud lib pinned to a specific commit but  get the latest dynamite_runtime.
Worst case would be that consumers would need to add an override that also pins  dynamite_runtime.

Could @adil192 or @muelleel please test and provide feedback :)