### PR TITLE
neon: cleanup account handling

### DIFF
--- a/packages/neon/neon/lib/src/utils/global_options.dart
+++ b/packages/neon/neon/lib/src/utils/global_options.dart
@@ -41,7 +41,7 @@ class GlobalOptions {
         // Only override the initial account if there already has been a value,
         // which means it's not the initial emit from rememberLastUsedAccount
         if (initialAccount.hasValue) {
-          await initialAccount.set((await initialAccount.values.first).keys.toList()[0]);
+          await initialAccount.set((await initialAccount.values.first).keys.first);
         }
       }
     });


### PR DESCRIPTION
debugging the old implementation was not fun :)
I'd argue that the new one is also easier to read and less error prone as we filter out equal accounts on the stream level (`activeAccount..distinct()`) so we can't forget to check :)