### PR TITLE
neon: Fix image background antialiasing

### DIFF
--- a/packages/neon/neon/lib/src/widgets/image_wrapper.dart
+++ b/packages/neon/neon/lib/src/widgets/image_wrapper.dart
@@ -15,14 +15,17 @@ class NeonImageWrapper extends StatelessWidget {
   final BorderRadius? borderRadius;
 
   @override
-  Widget build(final BuildContext context) => SizedBox.fromSize(
-        size: size,
-        child: ClipRRect(
-          borderRadius: borderRadius ?? BorderRadius.zero,
-          child: ColoredBox(
-            color: color,
-            child: Center(
-              child: child,
+  Widget build(final BuildContext context) => ClipRRect(
+        borderRadius: borderRadius ?? BorderRadius.zero,
+        child: ColorFiltered(
+          colorFilter: ColorFilter.mode(color, BlendMode.dstATop),
+          child: SizedBox.fromSize(
+            size: size,
+            child: ColoredBox(
+              color: Colors.transparent,
+              child: Center(
+                child: child,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
Only today I realized that a color filter is needed to fix this. Previously I was trying to do it using a Stack or the background color, but that didn't work out due to the antialiasing that is applied

Before:
![image](https://github.com/provokateurin/nextcloud-neon/assets/26026535/f6a6a86e-975c-4409-ab48-fcec60d162c1)
After:
![image](https://github.com/provokateurin/nextcloud-neon/assets/26026535/9a9c534d-78fe-48b2-a980-bc5a7545d078)

