### PR TITLE
neon: ensure we allways have a scaffold to show snackbars

### DIFF
--- a/packages/neon/neon/lib/src/pages/home.dart
+++ b/packages/neon/neon/lib/src/pages/home.dart
@@ -570,7 +570,7 @@ class _HomePageState extends State<HomePage> {
                             );
                           }
                         }
-                        return Container();
+                        return const Scaffold();
                       },
                     ),
                   ),


### PR DESCRIPTION
In some cases like not having a connection to the server (in flightmode or server being down) we where trying to show a Snackbar without a Scaffold being in the Tree.

this mitigates the issue.