### PR TITLE
neon: Supress error when setting null active app

### DIFF
--- a/packages/neon/neon/lib/src/blocs/apps.dart
+++ b/packages/neon/neon/lib/src/blocs/apps.dart
@@ -133,7 +133,7 @@ class AppsBloc extends InteractiveBloc implements AppsBlocEvents, AppsBlocStates
       }
     } else if (appID == 'notifications') {
       openNotifications.add(null);
-    } else {
+    } else if (appID != null) {
       throw Exception('App $appID not found');
     }
   }


### PR DESCRIPTION
An error message was printed if no app on the server is supported by the client and therefore the active app was set to null.

From https://github.com/provokateurin/nextcloud-neon/pull/372