### PR TITLE
Refactor/feeds unread count sum

### DIFF
--- a/packages/neon/neon_news/lib/sort/folders.dart
+++ b/packages/neon/neon_news/lib/sort/folders.dart
@@ -3,7 +3,7 @@ part of '../neon_news.dart';
 final foldersSortBox = SortBox<FoldersSortProperty, FolderFeedsWrapper>(
   {
     FoldersSortProperty.alphabetical: (final folderFeedsWrapper) => folderFeedsWrapper.folder.name.toLowerCase(),
-    FoldersSortProperty.unreadCount: (final folderFeedsWrapper) => feedsUnreadCountSum(folderFeedsWrapper.feeds),
+    FoldersSortProperty.unreadCount: (final folderFeedsWrapper) => folderFeedsWrapper.feedsUnreadCountSum,
   },
   {
     FoldersSortProperty.alphabetical: Box(FoldersSortProperty.unreadCount, SortBoxOrder.descending),
@@ -19,6 +19,5 @@ class FolderFeedsWrapper {
 
   final NextcloudNewsFolder folder;
   final List<NextcloudNewsFeed> feeds;
+  int get feedsUnreadCountSum => feeds.fold(0, (final a, final b) => a + b.unreadCount!);
 }
-
-int feedsUnreadCountSum(final List<NextcloudNewsFeed> feeds) => feeds.fold(0, (final a, final b) => a + b.unreadCount!);

--- a/packages/neon/neon_news/lib/sort/folders.dart
+++ b/packages/neon/neon_news/lib/sort/folders.dart
@@ -21,9 +21,4 @@ class FolderFeedsWrapper {
   final List<NextcloudNewsFeed> feeds;
 }
 
-int feedsUnreadCountSum(final List<NextcloudNewsFeed> feeds) => [
-      0, // Fixes error when no feeds are in the folder
-      ...feeds.map((final f) => f.unreadCount!),
-    ].reduce(
-      (final a, final b) => a + b,
-    );
+int feedsUnreadCountSum(final List<NextcloudNewsFeed> feeds) => feeds.fold(0, (final a, final b) => a + b.unreadCount!);

--- a/packages/neon/neon_news/lib/sort/folders.dart
+++ b/packages/neon/neon_news/lib/sort/folders.dart
@@ -2,8 +2,8 @@ part of '../neon_news.dart';
 
 final foldersSortBox = SortBox<FoldersSortProperty, FolderFeedsWrapper>(
   {
-    FoldersSortProperty.alphabetical: (final folderFeedsWrapper) => folderFeedsWrapper.folder.name.toLowerCase(),
-    FoldersSortProperty.unreadCount: (final folderFeedsWrapper) => folderFeedsWrapper.feedsUnreadCountSum,
+    FoldersSortProperty.alphabetical: (final folderFeedsWrapper) => folderFeedsWrapper.$1.name.toLowerCase(),
+    FoldersSortProperty.unreadCount: (final folderFeedsWrapper) => folderFeedsWrapper.$3,
   },
   {
     FoldersSortProperty.alphabetical: Box(FoldersSortProperty.unreadCount, SortBoxOrder.descending),
@@ -11,13 +11,4 @@ final foldersSortBox = SortBox<FoldersSortProperty, FolderFeedsWrapper>(
   },
 );
 
-class FolderFeedsWrapper {
-  FolderFeedsWrapper(
-    this.folder,
-    this.feeds,
-  );
-
-  final NextcloudNewsFolder folder;
-  final List<NextcloudNewsFeed> feeds;
-  int get feedsUnreadCountSum => feeds.fold(0, (final a, final b) => a + b.unreadCount!);
-}
+typedef FolderFeedsWrapper = (NextcloudNewsFolder folder, List<NextcloudNewsFeed> feeds, int unreadCount);

--- a/packages/neon/neon_news/lib/sort/folders.dart
+++ b/packages/neon/neon_news/lib/sort/folders.dart
@@ -11,4 +11,4 @@ final foldersSortBox = SortBox<FoldersSortProperty, FolderFeedsWrapper>(
   },
 );
 
-typedef FolderFeedsWrapper = (NextcloudNewsFolder folder, List<NextcloudNewsFeed> feeds, int unreadCount);
+typedef FolderFeedsWrapper = (NextcloudNewsFolder folder, int feedCount, int unreadCount);

--- a/packages/neon/neon_news/lib/widgets/folders_view.dart
+++ b/packages/neon/neon_news/lib/widgets/folders_view.dart
@@ -20,10 +20,11 @@ class NewsFoldersView extends StatelessWidget {
             input: feeds.data == null
                 ? null
                 : folders.data?.map((final folder) {
-                    final feedsInFolder = feeds.data!.where((final feed) => feed.folderId == folder.id).toList();
+                    final feedsInFolder = feeds.data!.where((final feed) => feed.folderId == folder.id);
+                    final feedCount = feedsInFolder.length;
                     final unreadCount = feedsInFolder.fold(0, (final a, final b) => a + b.unreadCount!);
 
-                    return (folder, feedsInFolder, unreadCount);
+                    return (folder, feedCount, unreadCount);
                   }).toList(),
             builder: (final context, final sorted) => NeonListView<FolderFeedsWrapper>(
               scrollKey: 'news-folders',
@@ -42,7 +43,7 @@ class NewsFoldersView extends StatelessWidget {
     final BuildContext context,
     final FolderFeedsWrapper folderFeedsWrapper,
   ) {
-    final (folder, feeds, unreadCount) = folderFeedsWrapper;
+    final (folder, feedCount, unreadCount) = folderFeedsWrapper;
     return ListTile(
       title: Text(
         folder.name,
@@ -66,7 +67,7 @@ class NewsFoldersView extends StatelessWidget {
             ),
             Center(
               child: Text(
-                feeds.length.toString(),
+                feedCount.toString(),
                 style: TextStyle(
                   color: Theme.of(context).colorScheme.onPrimary,
                 ),

--- a/packages/neon/neon_news/lib/widgets/folders_view.dart
+++ b/packages/neon/neon_news/lib/widgets/folders_view.dart
@@ -19,14 +19,12 @@ class NewsFoldersView extends StatelessWidget {
             sortBoxOrderOption: bloc.options.foldersSortBoxOrderOption,
             input: feeds.data == null
                 ? null
-                : folders.data
-                    ?.map(
-                      (final folder) => FolderFeedsWrapper(
-                        folder,
-                        feeds.data!.where((final feed) => feed.folderId == folder.id).toList(),
-                      ),
-                    )
-                    .toList(),
+                : folders.data?.map((final folder) {
+                    final feedsInFolder = feeds.data!.where((final feed) => feed.folderId == folder.id).toList();
+                    final unreadCount = feedsInFolder.fold(0, (final a, final b) => a + b.unreadCount!);
+
+                    return (folder, feedsInFolder, unreadCount);
+                  }).toList(),
             builder: (final context, final sorted) => NeonListView<FolderFeedsWrapper>(
               scrollKey: 'news-folders',
               withFloatingActionButton: true,
@@ -44,10 +42,10 @@ class NewsFoldersView extends StatelessWidget {
     final BuildContext context,
     final FolderFeedsWrapper folderFeedsWrapper,
   ) {
-    final unreadCount = folderFeedsWrapper.feedsUnreadCountSum;
+    final (folder, feeds, unreadCount) = folderFeedsWrapper;
     return ListTile(
       title: Text(
-        folderFeedsWrapper.folder.name,
+        folder.name,
         style: unreadCount == 0
             ? Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).disabledColor)
             : null,
@@ -68,7 +66,7 @@ class NewsFoldersView extends StatelessWidget {
             ),
             Center(
               child: Text(
-                folderFeedsWrapper.feeds.length.toString(),
+                feeds.length.toString(),
                 style: TextStyle(
                   color: Theme.of(context).colorScheme.onPrimary,
                 ),
@@ -95,19 +93,19 @@ class NewsFoldersView extends StatelessWidget {
               if (await showConfirmationDialog(
                 context,
                 // ignore: use_build_context_synchronously
-                AppLocalizations.of(context).folderDeleteConfirm(folderFeedsWrapper.folder.name),
+                AppLocalizations.of(context).folderDeleteConfirm(folder.name),
               )) {
-                bloc.deleteFolder(folderFeedsWrapper.folder.id);
+                bloc.deleteFolder(folder.id);
               }
               break;
             case NewsFolderAction.rename:
               final result = await showRenameDialog(
                 context: context,
                 title: AppLocalizations.of(context).folderRename,
-                value: folderFeedsWrapper.folder.name,
+                value: folder.name,
               );
               if (result != null) {
-                bloc.renameFolder(folderFeedsWrapper.folder.id, result);
+                bloc.renameFolder(folder.id, result);
               }
               break;
           }
@@ -115,7 +113,7 @@ class NewsFoldersView extends StatelessWidget {
       ),
       onLongPress: () {
         if (unreadCount > 0) {
-          bloc.markFolderAsRead(folderFeedsWrapper.folder.id);
+          bloc.markFolderAsRead(folder.id);
         }
       },
       onTap: () async {
@@ -123,7 +121,7 @@ class NewsFoldersView extends StatelessWidget {
           MaterialPageRoute(
             builder: (final context) => NewsFolderPage(
               bloc: bloc,
-              folder: folderFeedsWrapper.folder,
+              folder: folder,
             ),
           ),
         );

--- a/packages/neon/neon_news/lib/widgets/folders_view.dart
+++ b/packages/neon/neon_news/lib/widgets/folders_view.dart
@@ -44,7 +44,7 @@ class NewsFoldersView extends StatelessWidget {
     final BuildContext context,
     final FolderFeedsWrapper folderFeedsWrapper,
   ) {
-    final unreadCount = feedsUnreadCountSum(folderFeedsWrapper.feeds);
+    final unreadCount = folderFeedsWrapper.feedsUnreadCountSum;
     return ListTile(
       title: Text(
         folderFeedsWrapper.folder.name,


### PR DESCRIPTION
This should improve performance just how we compute the unreadCount (not needing to copy the list in memory) and also by caching the unreadcount.

We can sqash on merge if desired