### PR TITLE
neon_files: Force depth to 1 for listing files

### DIFF
--- a/packages/neon/neon_files/lib/blocs/browser.dart
+++ b/packages/neon/neon_files/lib/blocs/browser.dart
@@ -54,6 +54,7 @@ class FilesBrowserBloc extends InteractiveBloc implements FilesBrowserBlocEvents
           ocsize: true,
           ocfavorite: true,
         ),
+        depth: '1',
       ),
       (final response) => response.toWebDavFiles(client.webdav).sublist(1),
       emitEmptyCache: true,


### PR DESCRIPTION
It seems like different webdav server implementations used different defaults for the depth. Nextcloud apparently uses 1 as the default so this was working fine (and technically isn't really a fix).

From https://github.com/provokateurin/nextcloud-neon/pull/372