### PR TITLE
neon_files: Do not expect props to be available

### DIFF
--- a/packages/neon/neon_files/lib/models/file_details.dart
+++ b/packages/neon/neon_files/lib/models/file_details.dart
@@ -19,13 +19,13 @@ class FileDetails {
 
   final bool isDirectory;
 
-  final int size;
+  final int? size;
 
   final String? etag;
 
   final String? mimeType;
 
-  final DateTime lastModified;
+  final DateTime? lastModified;
 
   final bool? hasPreview;
 

--- a/packages/neon/neon_files/lib/pages/details.dart
+++ b/packages/neon/neon_files/lib/pages/details.dart
@@ -46,10 +46,15 @@ class FilesDetailsPage extends StatelessWidget {
                         : AppLocalizations.of(context).detailsFileName: details.name,
                     AppLocalizations.of(context).detailsParentFolder:
                         details.path.length == 1 ? '/' : details.path.sublist(0, details.path.length - 1).join('/'),
-                    details.isDirectory
-                        ? AppLocalizations.of(context).detailsFolderSize
-                        : AppLocalizations.of(context).detailsFileSize: filesize(details.size, 1),
-                    AppLocalizations.of(context).detailsLastModified: details.lastModified.toLocal().toIso8601String(),
+                    if (details.size != null) ...{
+                      details.isDirectory
+                          ? AppLocalizations.of(context).detailsFolderSize
+                          : AppLocalizations.of(context).detailsFileSize: filesize(details.size, 1),
+                    },
+                    if (details.lastModified != null) ...{
+                      AppLocalizations.of(context).detailsLastModified:
+                          details.lastModified!.toLocal().toIso8601String(),
+                    },
                     if (details.isFavorite != null) ...{
                       AppLocalizations.of(context).detailsIsFavorite: details.isFavorite!
                           ? AppLocalizations.of(context).actionYes

--- a/packages/neon/neon_files/lib/pages/main.dart
+++ b/packages/neon/neon_files/lib/pages/main.dart
@@ -29,7 +29,7 @@ class _FilesMainPageState extends State<FilesMainPage> {
           filesBloc: bloc,
           onPickFile: (final details) async {
             final sizeWarning = bloc.options.downloadSizeWarning.value;
-            if (sizeWarning != null && details.size > sizeWarning) {
+            if (sizeWarning != null && details.size != null && details.size! > sizeWarning) {
               // ignore: use_build_context_synchronously
               if (!(await showConfirmationDialog(
                 context,

--- a/packages/neon/neon_files/lib/widgets/browser_view.dart
+++ b/packages/neon/neon_files/lib/widgets/browser_view.dart
@@ -116,12 +116,12 @@ class _FilesBrowserViewState extends State<FilesBrowserView> {
                                               isDirectory: matchingUploadTasks.isEmpty && file.isDirectory,
                                               size: matchingUploadTasks.isNotEmpty
                                                   ? matchingUploadTasks.first.size
-                                                  : file.size!,
+                                                  : file.size,
                                               etag: matchingUploadTasks.isNotEmpty ? null : file.etag,
                                               mimeType: matchingUploadTasks.isNotEmpty ? null : file.mimeType,
                                               lastModified: matchingUploadTasks.isNotEmpty
                                                   ? matchingUploadTasks.first.lastModified
-                                                  : file.lastModified!,
+                                                  : file.lastModified,
                                               hasPreview: matchingUploadTasks.isNotEmpty ? null : file.hasPreview,
                                               isFavorite: matchingUploadTasks.isNotEmpty ? null : file.favorite,
                                             ),
@@ -235,10 +235,12 @@ class _FilesBrowserViewState extends State<FilesBrowserView> {
         ),
         subtitle: Row(
           children: [
-            RelativeTime(
-              date: details.lastModified,
-            ),
-            if (details.size > 0) ...[
+            if (details.lastModified != null) ...[
+              RelativeTime(
+                date: details.lastModified!,
+              ),
+            ],
+            if (details.size != null && details.size! > 0) ...[
               const SizedBox(
                 width: 10,
               ),
@@ -396,7 +398,7 @@ class _FilesBrowserViewState extends State<FilesBrowserView> {
                       break;
                     case FilesFileAction.sync:
                       final sizeWarning = widget.bloc.options.downloadSizeWarning.value;
-                      if (sizeWarning != null && details.size > sizeWarning) {
+                      if (sizeWarning != null && details.size != null && details.size! > sizeWarning) {
                         // ignore: use_build_context_synchronously
                         if (!(await showConfirmationDialog(
                           context,


### PR DESCRIPTION
Currently we expect the props to be returned when we request them, but it might not be always the case (failure on the server or a different implementation that doesn't support the requested props). Also useful for later if we want to support props that depend on an app being installed on the server which might not be installed on the particular instance.

From https://github.com/provokateurin/nextcloud-neon/pull/372