### PR TITLE
RFC: Feature/error bloc

### DIFF
--- a/packages/neon/neon/lib/neon.dart
+++ b/packages/neon/neon/lib/neon.dart
@@ -24,6 +24,7 @@ import 'package:neon/l10n/localizations.dart';
 import 'package:neon/src/blocs/blocs.dart';
 import 'package:neon/src/models/account.dart';
 import 'package:neon/src/models/push_notification.dart';
+import 'package:neon/src/pages/no_apps.dart';
 import 'package:neon/src/router.dart';
 import 'package:neon/src/widgets/drawer.dart';
 import 'package:neon/src/widgets/drawer_destination.dart';

--- a/packages/neon/neon/lib/src/blocs/blocs.dart
+++ b/packages/neon/neon/lib/src/blocs/blocs.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
+import 'package:neon/l10n/localizations.dart';
 import 'package:neon/neon.dart';
 import 'package:nextcloud/nextcloud.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -14,6 +15,7 @@ import 'package:window_manager/window_manager.dart';
 part 'accounts.dart';
 part 'apps.dart';
 part 'capabilities.dart';
+part 'error.dart';
 part 'first_launch.dart';
 part 'login.dart';
 part 'next_push.dart';

--- a/packages/neon/neon/lib/src/blocs/error.dart
+++ b/packages/neon/neon/lib/src/blocs/error.dart
@@ -1,0 +1,88 @@
+part of 'blocs.dart';
+
+typedef TranslationCallback = String Function(AppLocalizations l10n);
+
+abstract class ErrorBlocEvents {
+  /// Adds an error to the [ErrorBlocStates.globalErrors].
+  ///
+  /// Used to signal non app specific errors.
+  void addGlobalError(final String message);
+
+  /// Adds an error to the [ErrorBlocStates.appErrors].
+  ///
+  /// Used to signal errors specific to an app identified by [appId].
+  void addAppError(final String appId, final String message);
+}
+
+abstract class ErrorBlocStates {
+  /// Errors for the global neon framework.
+  BehaviorSubject<String> get globalErrors;
+
+  /// Errors for a specific app.
+  Map<String, BehaviorSubject<String>> get appErrors;
+}
+
+/// Holds error messages to be displayed by the UI
+///
+/// It will cache the last emmited error.
+/// The [ErrorBloc] is a singleton.
+class ErrorBloc extends Bloc implements ErrorBlocEvents, ErrorBlocStates {
+  factory ErrorBloc() => instance ??= ErrorBloc._();
+
+  @visibleForTesting
+  factory ErrorBloc.mocked(final ErrorBloc mock) => instance ??= mock;
+
+  ErrorBloc._();
+
+  @visibleForTesting
+  static ErrorBloc? instance;
+
+  AppLocalizations? l10n;
+
+  @override
+  final BehaviorSubject<String> globalErrors = BehaviorSubject();
+  @override
+  final Map<String, BehaviorSubject<String>> appErrors = {};
+
+  @override
+  void dispose() {
+    ErrorBloc.instance = null;
+  }
+
+  @override
+  void addGlobalError(final String message) {
+    globalErrors.add(message);
+  }
+
+  @override
+  void addAppError(final String appId, final String message) {
+    if (appErrors[appId] == null) {
+      appErrors[appId] = BehaviorSubject();
+    }
+
+    appErrors[appId]!.add(message);
+  }
+
+  void addVersionErrors(final Iterable<(String, Object?)> errors) {
+    assert(l10n != null, 'Localization must be register to process version Errors.');
+
+    final buffer = StringBuffer();
+
+    for (final error in errors) {
+      // TODO: reword errorUnsupportedVersion to support multiple errors
+      // TODO: add version info
+
+      final (appId, minVersion) = error;
+      final appName = l10n!.appImplementationName(appId);
+      final message = l10n!.errorUnsupportedVersion(appName);
+
+      buffer.write(message);
+    }
+
+    if (buffer.isNotEmpty) {
+      addGlobalError(buffer.toString());
+    }
+  }
+
+  String translateError(final TranslationCallback callback) => callback(l10n!);
+}

--- a/packages/neon/neon/lib/src/pages/home.dart
+++ b/packages/neon/neon/lib/src/pages/home.dart
@@ -11,7 +11,6 @@ class HomePage extends StatefulWidget {
   State<HomePage> createState() => _HomePageState();
 }
 
-// ignore: prefer_mixin
 class _HomePageState extends State<HomePage> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
   final drawerScrollController = ScrollController();
@@ -20,7 +19,6 @@ class _HomePageState extends State<HomePage> {
   late GlobalOptions _globalOptions;
   late AccountsBloc _accountsBloc;
   late AppsBloc _appsBloc;
-  late CapabilitiesBloc _capabilitiesBloc;
 
   @override
   void initState() {
@@ -29,7 +27,6 @@ class _HomePageState extends State<HomePage> {
     _accountsBloc = Provider.of<AccountsBloc>(context, listen: false);
     _account = _accountsBloc.activeAccount.value!;
     _appsBloc = _accountsBloc.activeAppsBloc;
-    _capabilitiesBloc = _accountsBloc.activeCapabilitiesBloc;
 
     _appsBloc.openNotifications.listen((final _) async {
       final notificationsAppImplementation = _appsBloc.notificationsAppImplementation.valueOrNull;
@@ -39,47 +36,6 @@ class _HomePageState extends State<HomePage> {
           _accountsBloc.accounts.value,
           _accountsBloc.activeAccount.value!,
         );
-      }
-    });
-
-    _capabilitiesBloc.capabilities.listen((final result) async {
-      if (result.data != null) {
-        // ignore cached version and prevent duplicate dialogs
-        if (result.cached) {
-          return;
-        }
-        _appsBloc.appImplementations.listen((final appsResult) async {
-          // ignore cached version and prevent duplicate dialogs
-          if (appsResult.data == null || appsResult.cached) {
-            return;
-          }
-          for (final id in [
-            'core',
-            ...appsResult.data!.map((final a) => a.id),
-          ]) {
-            try {
-              final (supported, _) = switch (id) {
-                'core' => await _account.client.core.isSupported(result.data),
-                'news' => await _account.client.news.isSupported(),
-                'notes' => await _account.client.notes.isSupported(result.data),
-                _ => (true, null),
-              };
-              if (supported || !mounted) {
-                return;
-              }
-              var name = AppLocalizations.of(context).appImplementationName(id);
-              if (name == '') {
-                name = id;
-              }
-              await _showProblem(
-                AppLocalizations.of(context).errorUnsupportedVersion(name),
-              );
-            } catch (e, s) {
-              debugPrint(e.toString());
-              debugPrint(s.toString());
-            }
-          }
-        });
       }
     });
 
@@ -168,164 +124,161 @@ class _HomePageState extends State<HomePage> {
   }
 
   @override
-  Widget build(final BuildContext context) => ResultBuilder<Capabilities>(
-        stream: _capabilitiesBloc.capabilities,
-        builder: (final context, final capabilities) => ResultBuilder<Iterable<AppImplementation>>(
-          stream: _appsBloc.appImplementations,
-          builder: (final context, final appImplementations) => ResultBuilder<NotificationsAppInterface?>(
-            stream: _appsBloc.notificationsAppImplementation,
-            builder: (final context, final notificationsAppImplementation) => StreamBuilder<String?>(
-              stream: _appsBloc.activeAppID,
-              builder: (final context, final activeAppIDSnapshot) => StreamBuilder<List<Account>>(
-                stream: _accountsBloc.accounts,
-                builder: (final context, final accountsSnapshot) => OptionBuilder<NavigationMode>(
-                  option: _globalOptions.navigationMode,
-                  builder: (final context, final navigationMode) {
-                    final accounts = accountsSnapshot.data;
-                    final account = accounts?.find(_account.id);
-                    if (accounts == null || account == null) {
-                      return const Scaffold();
-                    }
+  Widget build(final BuildContext context) => ResultBuilder<Iterable<AppImplementation>>(
+        stream: _appsBloc.appImplementations,
+        builder: (final context, final appImplementations) => ResultBuilder<NotificationsAppInterface?>(
+          stream: _appsBloc.notificationsAppImplementation,
+          builder: (final context, final notificationsAppImplementation) => StreamBuilder<String?>(
+            stream: _appsBloc.activeAppID,
+            builder: (final context, final activeAppIDSnapshot) => StreamBuilder<List<Account>>(
+              stream: _accountsBloc.accounts,
+              builder: (final context, final accountsSnapshot) => OptionBuilder<NavigationMode>(
+                option: _globalOptions.navigationMode,
+                builder: (final context, final navigationMode) {
+                  final accounts = accountsSnapshot.data;
+                  final account = accounts?.find(_account.id);
+                  if (accounts == null || account == null) {
+                    return const Scaffold();
+                  }
 
-                    final drawerAlwaysVisible = navigationMode == NavigationMode.drawerAlwaysVisible;
+                  final drawerAlwaysVisible = navigationMode == NavigationMode.drawerAlwaysVisible;
 
-                    const drawer = NeonDrawer();
-                    final appBar = AppBar(
-                      automaticallyImplyLeading: !drawerAlwaysVisible,
-                      title: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            children: [
-                              if (appImplementations.data != null && activeAppIDSnapshot.hasData) ...[
-                                Flexible(
-                                  child: Text(
-                                    appImplementations.data!.find(activeAppIDSnapshot.data!)!.name(context),
-                                  ),
+                  const drawer = NeonDrawer();
+                  final appBar = AppBar(
+                    automaticallyImplyLeading: !drawerAlwaysVisible,
+                    title: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            if (appImplementations.data != null && activeAppIDSnapshot.hasData) ...[
+                              Flexible(
+                                child: Text(
+                                  appImplementations.data!.find(activeAppIDSnapshot.data!)!.name(context),
                                 ),
-                              ],
-                              if (appImplementations.error != null) ...[
-                                const SizedBox(
-                                  width: 8,
-                                ),
-                                NeonException(
-                                  appImplementations.error,
-                                  onRetry: _appsBloc.refresh,
-                                  onlyIcon: true,
-                                ),
-                              ],
-                              if (appImplementations.loading) ...[
-                                const SizedBox(
-                                  width: 8,
-                                ),
-                                Expanded(
-                                  child: NeonLinearProgressIndicator(
-                                    color: Theme.of(context).appBarTheme.foregroundColor,
-                                  ),
-                                ),
-                              ],
+                              ),
                             ],
-                          ),
-                          if (accounts.length > 1) ...[
-                            Text(
-                              account.client.humanReadableID,
-                              style: Theme.of(context).textTheme.bodySmall,
-                            ),
-                          ],
-                        ],
-                      ),
-                      actions: [
-                        if (notificationsAppImplementation.data != null) ...[
-                          StreamBuilder<int>(
-                            stream: notificationsAppImplementation.data!
-                                .getUnreadCounter(notificationsAppImplementation.data!.getBloc(account)),
-                            builder: (final context, final unreadCounterSnapshot) {
-                              final unreadCount = unreadCounterSnapshot.data ?? 0;
-                              return IconButton(
-                                key: Key('app-${notificationsAppImplementation.data!.id}'),
-                                onPressed: () async {
-                                  await _openNotifications(
-                                    notificationsAppImplementation.data!,
-                                    accounts,
-                                    account,
-                                  );
-                                },
-                                tooltip: AppLocalizations.of(context)
-                                    .appImplementationName(notificationsAppImplementation.data!.id),
-                                icon: NeonAppImplementationIcon(
-                                  appImplementation: notificationsAppImplementation.data!,
-                                  unreadCount: unreadCount,
-                                  color: unreadCount > 0
-                                      ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).colorScheme.onBackground,
-                                  size: const Size.square(kAvatarSize * 2 / 3),
+                            if (appImplementations.error != null) ...[
+                              const SizedBox(
+                                width: 8,
+                              ),
+                              NeonException(
+                                appImplementations.error,
+                                onRetry: _appsBloc.refresh,
+                                onlyIcon: true,
+                              ),
+                            ],
+                            if (appImplementations.loading) ...[
+                              const SizedBox(
+                                width: 8,
+                              ),
+                              Expanded(
+                                child: NeonLinearProgressIndicator(
+                                  color: Theme.of(context).appBarTheme.foregroundColor,
                                 ),
-                              );
-                            },
+                              ),
+                            ],
+                          ],
+                        ),
+                        if (accounts.length > 1) ...[
+                          Text(
+                            account.client.humanReadableID,
+                            style: Theme.of(context).textTheme.bodySmall,
                           ),
                         ],
-                        IconButton(
-                          onPressed: () {
-                            AccountSettingsRoute(accountid: account.id).go(context);
+                      ],
+                    ),
+                    actions: [
+                      if (notificationsAppImplementation.data != null) ...[
+                        StreamBuilder<int>(
+                          stream: notificationsAppImplementation.data!
+                              .getUnreadCounter(notificationsAppImplementation.data!.getBloc(account)),
+                          builder: (final context, final unreadCounterSnapshot) {
+                            final unreadCount = unreadCounterSnapshot.data ?? 0;
+                            return IconButton(
+                              key: Key('app-${notificationsAppImplementation.data!.id}'),
+                              onPressed: () async {
+                                await _openNotifications(
+                                  notificationsAppImplementation.data!,
+                                  accounts,
+                                  account,
+                                );
+                              },
+                              tooltip: AppLocalizations.of(context)
+                                  .appImplementationName(notificationsAppImplementation.data!.id),
+                              icon: NeonAppImplementationIcon(
+                                appImplementation: notificationsAppImplementation.data!,
+                                unreadCount: unreadCount,
+                                color: unreadCount > 0
+                                    ? Theme.of(context).colorScheme.primary
+                                    : Theme.of(context).colorScheme.onBackground,
+                                size: const Size.square(kAvatarSize * 2 / 3),
+                              ),
+                            );
                           },
-                          tooltip: AppLocalizations.of(context).settingsAccount,
-                          icon: NeonUserAvatar(
-                            account: account,
-                          ),
+                        ),
+                      ],
+                      IconButton(
+                        onPressed: () {
+                          AccountSettingsRoute(accountid: account.id).go(context);
+                        },
+                        tooltip: AppLocalizations.of(context).settingsAccount,
+                        icon: NeonUserAvatar(
+                          account: account,
+                        ),
+                      ),
+                    ],
+                  );
+
+                  Widget body = Builder(
+                    builder: (final context) {
+                      if (appImplementations.data == null) {
+                        return const SizedBox.shrink();
+                      }
+
+                      if (appImplementations.data!.isEmpty) {
+                        return const NoAppsPage();
+                      }
+
+                      return appImplementations.data!.find(activeAppIDSnapshot.data!)!.page;
+                    },
+                  );
+
+                  body = MultiProvider(
+                    providers: _appsBloc.appBlocProviders,
+                    child: Scaffold(
+                      key: _scaffoldKey,
+                      resizeToAvoidBottomInset: false,
+                      drawer: !drawerAlwaysVisible ? drawer : null,
+                      appBar: appBar,
+                      body: body,
+                    ),
+                  );
+
+                  if (drawerAlwaysVisible) {
+                    body = Row(
+                      children: [
+                        drawer,
+                        Expanded(
+                          child: body,
                         ),
                       ],
                     );
+                  }
 
-                    Widget body = Builder(
-                      builder: (final context) {
-                        if (appImplementations.data == null) {
-                          return const SizedBox.shrink();
-                        }
+                  return WillPopScope(
+                    onWillPop: () async {
+                      if (_scaffoldKey.currentState!.isDrawerOpen) {
+                        Navigator.pop(context);
+                        return true;
+                      }
 
-                        if (appImplementations.data!.isEmpty) {
-                          return const NoAppsPage();
-                        }
-
-                        return appImplementations.data!.find(activeAppIDSnapshot.data!)!.page;
-                      },
-                    );
-
-                    body = MultiProvider(
-                      providers: _appsBloc.appBlocProviders,
-                      child: Scaffold(
-                        key: _scaffoldKey,
-                        resizeToAvoidBottomInset: false,
-                        drawer: !drawerAlwaysVisible ? drawer : null,
-                        appBar: appBar,
-                        body: body,
-                      ),
-                    );
-
-                    if (drawerAlwaysVisible) {
-                      body = Row(
-                        children: [
-                          drawer,
-                          Expanded(
-                            child: body,
-                          ),
-                        ],
-                      );
-                    }
-
-                    return WillPopScope(
-                      onWillPop: () async {
-                        if (_scaffoldKey.currentState!.isDrawerOpen) {
-                          Navigator.pop(context);
-                          return true;
-                        }
-
-                        _scaffoldKey.currentState!.openDrawer();
-                        return false;
-                      },
-                      child: body,
-                    );
-                  },
-                ),
+                      _scaffoldKey.currentState!.openDrawer();
+                      return false;
+                    },
+                    child: body,
+                  );
+                },
               ),
             ),
           ),

--- a/packages/neon/neon/lib/src/pages/home.dart
+++ b/packages/neon/neon/lib/src/pages/home.dart
@@ -277,28 +277,17 @@ class _HomePageState extends State<HomePage> {
                     );
 
                     Widget body = Builder(
-                      builder: (final context) => Column(
-                        children: [
-                          if (appImplementations.data != null) ...[
-                            if (appImplementations.data!.isEmpty) ...[
-                              Expanded(
-                                child: Center(
-                                  child: Text(
-                                    AppLocalizations.of(context).errorNoCompatibleNextcloudAppsFound,
-                                    textAlign: TextAlign.center,
-                                  ),
-                                ),
-                              ),
-                            ] else ...[
-                              if (activeAppIDSnapshot.hasData) ...[
-                                Expanded(
-                                  child: appImplementations.data!.find(activeAppIDSnapshot.data!)!.page,
-                                ),
-                              ],
-                            ],
-                          ],
-                        ],
-                      ),
+                      builder: (final context) {
+                        if (appImplementations.data == null) {
+                          return const SizedBox.shrink();
+                        }
+
+                        if (appImplementations.data!.isEmpty) {
+                          return const NoAppsPage();
+                        }
+
+                        return appImplementations.data!.find(activeAppIDSnapshot.data!)!.page;
+                      },
                     );
 
                     body = MultiProvider(

--- a/packages/neon/neon/lib/src/pages/no_apps.dart
+++ b/packages/neon/neon/lib/src/pages/no_apps.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:meta/meta.dart';
+import 'package:neon/l10n/localizations.dart';
+
+@internal
+class NoAppsPage extends StatelessWidget {
+  const NoAppsPage({super.key});
+
+  @override
+  Widget build(final BuildContext context) => Center(
+        child: Text(
+          AppLocalizations.of(context).errorNoCompatibleNextcloudAppsFound,
+          textAlign: TextAlign.center,
+        ),
+      );
+}


### PR DESCRIPTION
I need some feedback for the second commit:

### Problem:
I want to get rid of
https://github.com/provokateurin/nextcloud-neon/blob/bba5c2b5757c2897f9810aded8cfc41738589ce4/packages/neon/neon/lib/src/pages/home.dart#L45-L84

As it's not really UI related and should be part of the blocs. On the other hand we are adding new listeners whenever the capabilities change and don't dispose the old ones wich could hunt us in the future.
Finally we search for the first unsupported app and then immediately show an error wich could be bad Ux when multiple apps are outdated a user might inform their admin about the needed changes and only afterwards find out that another app also needs updating (yeah bad admin if they don't just update everything when being in there but it's possible).

### Idea:
As you can see I moved the logic into the appsBloc and my Idea is to just communicate back to the UI if we find a mismatch. 
I thought of implementing an ErrorBloc where global errors or app specific errors can be added. This would allow us to have a central place to display and handle errors (no more 5 error icons similar to our multiple error bars).

### Problems with the Proposal:
we'd somehow need access to the l10n form within our ErrorBloc (see the commit) and I don't like this :(
We'd need to keep the l10n reference in the bloc updated when the language changes...

What do you think?

---

The first commit can be disregarded just some experiments for now.