### PR TITLE
Fix/flatpak

### DIFF
--- a/packages/app/de.provokateurin.neon.desktop
+++ b/packages/app/de.provokateurin.neon.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Nextcloud Neon
+Icon=de.provokateurin.neon
+Exec=nextcloud-neon %U
+Keywords=Nextcloud;Neon

--- a/packages/app/de.provokateurin.neon.yaml
+++ b/packages/app/de.provokateurin.neon.yaml
@@ -9,8 +9,20 @@ finish-args:
   - --socket=wayland
   - --share=network
   - --device=dri
+  - --env=LD_LIBRARY_PATH=/app/lib/:/app/nextcloud-neon/lib/
 modules:
   - ../../external/flathub-shared-modules/libappindicator/libappindicator-gtk3-12.10.json
+  - name: aarch64-quirks
+    only-arches: [aarch64]
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/nextcloud-neon/lib
+      - ln -s /usr/lib/aarch64-linux-gnu/libsqlite3.so.0 /app/nextcloud-neon/lib/libsqlite3.so
+      - ln -s /app/lib/libappindicator3.so /app/lib/libayatana-appindicator3.so.1
+      - ln -s /app/lib/libappindicator3.so /app/lib/libayatana-appindicator3.so.7
+      - ln -s /app/lib/libindicator3.so /app/lib/libayatana-indicator3.so.7
+      - ln -s /app/lib/libindicator3.so /app/lib/libayatana-ido3-0.4.so.0
+      - mkdir -p /app/bin
   - name: x86_64-quirks
     only-arches: [x86_64]
     buildsystem: simple

--- a/packages/app/de.provokateurin.neon.yaml
+++ b/packages/app/de.provokateurin.neon.yaml
@@ -11,6 +11,12 @@ finish-args:
   - --device=dri
 modules:
   - ../../external/flathub-shared-modules/libappindicator/libappindicator-gtk3-12.10.json
+  - name: x86_64-quirks
+    only-arches: [x86_64]
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/nextcloud-neon/lib
+      - ln -s /usr/lib/x86_64-linux-gnu/libsqlite3.so.0 /app/nextcloud-neon/lib/libsqlite3.so
   - name: nextcloud-neon
     buildsystem: simple
     build-commands:
@@ -18,8 +24,6 @@ modules:
       - cp nextcloud-neon /app/nextcloud-neon/
       - cp *.so /app/nextcloud-neon/lib/
       - cp -r flutter_assets icudtl.dat /app/nextcloud-neon/data/
-      - ln -s /usr/lib/x86_64-linux-gnu/libsqlite3.so.0 /app/lib/libsqlite3.so
-      - if [ ! -e '/app/lib/libsqlite3.so' ]; then ln -s -f /usr/lib/aarch64-linux-gnu/libsqlite3.so.0 /app/lib/libsqlite3.so; fi
       - ln -sf /app/nextcloud-neon/nextcloud-neon /app/bin/nextcloud-neon
       - install -Dm644 de.provokateurin.neon.desktop /app/share/applications/de.provokateurin.neon.desktop
       - install -Dm644 logo.svg /app/share/icons/hicolor/scalable/apps/de.provokateurin.neon.svg

--- a/packages/app/de.provokateurin.neon.yaml
+++ b/packages/app/de.provokateurin.neon.yaml
@@ -21,7 +21,13 @@ modules:
       - ln -s /usr/lib/x86_64-linux-gnu/libsqlite3.so.0 /app/lib/libsqlite3.so
       - if [ ! -e '/app/lib/libsqlite3.so' ]; then ln -s -f /usr/lib/aarch64-linux-gnu/libsqlite3.so.0 /app/lib/libsqlite3.so; fi
       - ln -sf /app/nextcloud-neon/nextcloud-neon /app/bin/nextcloud-neon
+      - install -Dm644 de.provokateurin.neon.desktop /app/share/applications/de.provokateurin.neon.desktop
+      - install -Dm644 logo.svg /app/share/icons/hicolor/scalable/apps/de.provokateurin.neon.svg
     sources:
+      - type: file
+        path: de.provokateurin.neon.desktop
+      - type: file
+        path: assets/logo.svg
       - type: file
         path: build/linux/x64/release/bundle/nextcloud-neon
       - type: dir

--- a/packages/app/de.provokateurin.neon.yaml
+++ b/packages/app/de.provokateurin.neon.yaml
@@ -33,8 +33,20 @@ modules:
       - type: file
         path: assets/logo.svg
       - type: file
+        only-arches: [x86_64]
         path: build/linux/x64/release/bundle/nextcloud-neon
       - type: dir
+        only-arches: [x86_64]
         path: build/linux/x64/release/bundle/lib/
       - type: dir
+        only-arches: [x86_64]
         path: build/linux/x64/release/bundle/data/
+      - type: file
+        only-arches: [aarch64]
+        path: build/linux/arm64/release/bundle/nextcloud-neon
+      - type: dir
+        only-arches: [aarch64]
+        path: build/linux/arm64/release/bundle/lib/
+      - type: dir
+        only-arches: [aarch64]
+        path: build/linux/arm64/release/bundle/data/


### PR DESCRIPTION
The flatpak wasn't really useful without the desktop file and building and running the arm64 version was broken.
Now I can launch the arm64 on my x86_64 trough qemu binfmt using the menu entry of my DE :sunglasses: