### PR TITLE
app,dynamite_runtime,neon,neon_files,neon_news: Cleanup unused ignores

### DIFF
--- a/packages/app/test_driver/integration_test.dart
+++ b/packages/app/test_driver/integration_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:integration_test/integration_test_driver_extended.dart';
 
 Future<void> main() async {
@@ -15,7 +16,6 @@ Future<void> main() async {
       },
     );
   } catch (e) {
-    // ignore: avoid_print
-    print('Error occurred: $e');
+    debugPrint('Error occurred: $e');
   }
 }

--- a/packages/dynamite/dynamite_runtime/lib/src/content_string.dart
+++ b/packages/dynamite/dynamite_runtime/lib/src/content_string.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
-
 import 'dart:convert';
 
 import 'package:built_value/built_value.dart';

--- a/packages/neon/neon/lib/src/pages/account_settings.dart
+++ b/packages/neon/neon/lib/src/pages/account_settings.dart
@@ -22,21 +22,22 @@ class AccountSettingsPage extends StatelessWidget {
           actions: [
             IconButton(
               onPressed: () async {
-                // ignore: use_build_context_synchronously
                 if (await showConfirmationDialog(
                   context,
-                  // ignore: use_build_context_synchronously
                   AppLocalizations.of(context).accountOptionsRemoveConfirm(account.client.humanReadableID),
                 )) {
                   final isActive = bloc.activeAccount.value == account;
 
                   bloc.removeAccount(account);
 
+                  // ignore: use_build_context_synchronously
+                  if (!context.mounted) {
+                    return;
+                  }
+
                   if (isActive) {
-                    // ignore: use_build_context_synchronously
                     const HomeRoute().go(context);
                   } else {
-                    // ignore: use_build_context_synchronously
                     Navigator.of(context).pop();
                   }
                 }
@@ -46,10 +47,8 @@ class AccountSettingsPage extends StatelessWidget {
             ),
             IconButton(
               onPressed: () async {
-                // ignore: use_build_context_synchronously
                 if (await showConfirmationDialog(
                   context,
-                  // ignore: use_build_context_synchronously
                   AppLocalizations.of(context).settingsResetForConfirmation(_name),
                 )) {
                   await _options.reset();

--- a/packages/neon/neon/lib/src/pages/login.dart
+++ b/packages/neon/neon/lib/src/pages/login.dart
@@ -84,8 +84,10 @@ class _LoginPageState extends State<LoginPage> {
               ..addAccount(account)
               ..setActiveAccount(account);
           }
-          // ignore: use_build_context_synchronously
-          const HomeRoute().go(context);
+
+          if (mounted) {
+            const HomeRoute().go(context);
+          }
         } catch (e, s) {
           debugPrint(e.toString());
           debugPrint(s.toString());

--- a/packages/neon/neon/lib/src/pages/nextcloud_app_settings.dart
+++ b/packages/neon/neon/lib/src/pages/nextcloud_app_settings.dart
@@ -16,10 +16,8 @@ class NextcloudAppSettingsPage extends StatelessWidget {
           actions: [
             IconButton(
               onPressed: () async {
-                // ignore: use_build_context_synchronously
                 if (await showConfirmationDialog(
                   context,
-                  // ignore: use_build_context_synchronously
                   AppLocalizations.of(context).settingsResetForConfirmation(appImplementation.name(context)),
                 )) {
                   await appImplementation.options.reset();

--- a/packages/neon/neon/lib/src/pages/settings.dart
+++ b/packages/neon/neon/lib/src/pages/settings.dart
@@ -22,7 +22,6 @@ class _SettingsPageState extends State<SettingsPage> {
         actions: [
           IconButton(
             onPressed: () async {
-              // ignore: use_build_context_synchronously
               if (await showConfirmationDialog(context, AppLocalizations.of(context).settingsResetAllConfirmation)) {
                 await globalOptions.reset();
 

--- a/packages/neon/neon/lib/src/router.dart
+++ b/packages/neon/neon/lib/src/router.dart
@@ -1,4 +1,3 @@
-// ignore: prefer_mixin
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';

--- a/packages/neon/neon/lib/src/widgets/text_settings_tile.dart
+++ b/packages/neon/neon/lib/src/widgets/text_settings_tile.dart
@@ -1,6 +1,3 @@
-// ignore_for_file: use_late_for_private_fields_and_variables
-// ^ This is a really strange false positive, it goes of at a very random place without any meaning. Hopefully fixed soon?
-
 part of '../../neon.dart';
 
 class NeonTextSettingsTile extends SettingsTile {

--- a/packages/neon/neon_files/lib/dialogs/choose_create.dart
+++ b/packages/neon/neon_files/lib/dialogs/choose_create.dart
@@ -32,10 +32,8 @@ class _FilesChooseCreateDialogState extends State<FilesChooseCreateDialog> {
     if (sizeWarning != null) {
       final stat = file.statSync();
       if (stat.size > sizeWarning) {
-        // ignore: use_build_context_synchronously
         if (!(await showConfirmationDialog(
           context,
-          // ignore: use_build_context_synchronously
           AppLocalizations.of(context).uploadConfirmSizeWarning(
             filesize(sizeWarning),
             filesize(stat.size),

--- a/packages/neon/neon_files/lib/pages/main.dart
+++ b/packages/neon/neon_files/lib/pages/main.dart
@@ -30,10 +30,8 @@ class _FilesMainPageState extends State<FilesMainPage> {
           onPickFile: (final details) async {
             final sizeWarning = bloc.options.downloadSizeWarning.value;
             if (sizeWarning != null && details.size != null && details.size! > sizeWarning) {
-              // ignore: use_build_context_synchronously
               if (!(await showConfirmationDialog(
                 context,
-                // ignore: use_build_context_synchronously
                 AppLocalizations.of(context).downloadConfirmSizeWarning(
                   filesize(sizeWarning),
                   filesize(details.size),

--- a/packages/neon/neon_files/lib/widgets/browser_view.dart
+++ b/packages/neon/neon_files/lib/widgets/browser_view.dart
@@ -399,10 +399,8 @@ class _FilesBrowserViewState extends State<FilesBrowserView> {
                     case FilesFileAction.sync:
                       final sizeWarning = widget.bloc.options.downloadSizeWarning.value;
                       if (sizeWarning != null && details.size != null && details.size! > sizeWarning) {
-                        // ignore: use_build_context_synchronously
                         if (!(await showConfirmationDialog(
                           context,
-                          // ignore: use_build_context_synchronously
                           AppLocalizations.of(context).downloadConfirmSizeWarning(
                             filesize(sizeWarning),
                             filesize(details.size),
@@ -414,13 +412,10 @@ class _FilesBrowserViewState extends State<FilesBrowserView> {
                       widget.filesBloc.syncFile(details.path);
                       break;
                     case FilesFileAction.delete:
-                      // ignore: use_build_context_synchronously
                       if (await showConfirmationDialog(
                         context,
                         details.isDirectory
-                            // ignore: use_build_context_synchronously
                             ? AppLocalizations.of(context).folderDeleteConfirm(details.name)
-                            // ignore: use_build_context_synchronously
                             : AppLocalizations.of(context).fileDeleteConfirm(details.name),
                       )) {
                         widget.filesBloc.delete(details.path);

--- a/packages/neon/neon_news/lib/widgets/feeds_view.dart
+++ b/packages/neon/neon_news/lib/widgets/feeds_view.dart
@@ -113,10 +113,8 @@ class NewsFeedsView extends StatelessWidget {
                     );
                     break;
                   case NewsFeedAction.delete:
-                    // ignore: use_build_context_synchronously
                     if (await showConfirmationDialog(
                       context,
-                      // ignore: use_build_context_synchronously
                       AppLocalizations.of(context).feedRemoveConfirm(feed.title),
                     )) {
                       bloc.removeFeed(feed.id);

--- a/packages/neon/neon_news/lib/widgets/folders_view.dart
+++ b/packages/neon/neon_news/lib/widgets/folders_view.dart
@@ -86,10 +86,8 @@ class NewsFoldersView extends StatelessWidget {
         onSelected: (final action) async {
           switch (action) {
             case NewsFolderAction.delete:
-              // ignore: use_build_context_synchronously
               if (await showConfirmationDialog(
                 context,
-                // ignore: use_build_context_synchronously
                 AppLocalizations.of(context).folderDeleteConfirm(folder.name),
               )) {
                 bloc.deleteFolder(folder.id);


### PR DESCRIPTION
I removed all of the ignores and only added back where the linter complained. These were the ones that got removed and weren't necessary.