### PR TITLE
neon: Upgrade unifiedpush_android to fix unreliable push notifications

### DIFF
--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -1277,10 +1277,10 @@ packages:
     dependency: transitive
     description:
       name: unifiedpush_android
-      sha256: "6a81d05ea62084deed46a68a010d78081eee2ded66f056b1f729c77a0c61327a"
+      sha256: "559124eb1d6bcc5d8f422c8b9a942e52cc704858e6f0afad4c449feef654f1a3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   unifiedpush_platform_interface:
     dependency: transitive
     description:

--- a/packages/neon/neon/pubspec.yaml
+++ b/packages/neon/neon/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   sqflite_common_ffi: ^2.2.5
   tray_manager: ^0.2.0
   unifiedpush: ^5.0.0
+  unifiedpush_android: ^2.1.2
   url_launcher: ^6.1.11
   window_manager: ^0.3.2
   xdg_directories: ^1.0.0


### PR DESCRIPTION
Closes https://github.com/provokateurin/nextcloud-neon/issues/467

Was fixed in https://github.com/UnifiedPush/flutter-connector/commit/de9f39b5b6a8ad50af9b09eb93c52c2d71ce69f8, many thanks @p1gp1g