### PR TITLE
ci: Fix publish workflow concurrency

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: publish
+  cancel-in-progress: true
+
 env:
   PUB_CACHE: ~/.pub-cache
 


### PR DESCRIPTION
Fixes https://github.com/provokateurin/nextcloud-neon/issues/460