### PR TITLE
fix(tool): Reduce empty scope to warning

### DIFF
--- a/commitlint.yaml
+++ b/commitlint.yaml
@@ -2,7 +2,7 @@ include: package:commitlint_cli/commitlint.yaml
 
 rules:
   scope-empty:
-    - 2
+    - 1
     - never
   scope-enum:
     - 2


### PR DESCRIPTION
Allows having an empty scope. Still shows a warning when the scope is missing