### PR TITLE
Fix/web server

### DIFF
--- a/packages/nextcloud/test/helper.dart
+++ b/packages/nextcloud/test/helper.dart
@@ -144,7 +144,7 @@ Future<TestNextcloudClient> getTestClient(
   return client;
 }
 
-Future<DockerContainer> getDockerContainer(final DockerImage image) async {
+Future<DockerContainer> getDockerContainer(final DockerImage image, {final bool useApache = false}) async {
   late ProcessResult result;
   late int port;
   while (true) {
@@ -155,12 +155,16 @@ Future<DockerContainer> getDockerContainer(final DockerImage image) async {
         'run',
         '--rm',
         '-d',
-        '--net',
-        'host',
+        '--add-host',
+        'host.docker.internal:host-gateway',
+        '-p',
+        '$port:80',
         image,
-        'php',
-        '-S',
-        '0.0.0.0:$port',
+        if (!useApache) ...[
+          'php',
+          '-S',
+          '0.0.0.0:80',
+        ],
       ],
     );
     // 125 means the docker run command itself has failed which indicated the port is already used

--- a/packages/nextcloud/test/news_test.dart
+++ b/packages/nextcloud/test/news_test.dart
@@ -25,12 +25,12 @@ Future run(final DockerImage image) async {
     tearDown(() => container.destroy());
 
     Future<NewsListFeeds> addWikipediaFeed([final int? folderID]) => client.news.addFeed(
-          url: 'http://localhost:${rssServer.port}/wikipedia.xml',
+          url: 'http://host.docker.internal:${rssServer.port}/wikipedia.xml',
           folderId: folderID,
         );
 
     Future<NewsListFeeds> addNasaFeed() => client.news.addFeed(
-          url: 'http://localhost:${rssServer.port}/nasa.xml',
+          url: 'http://host.docker.internal:${rssServer.port}/nasa.xml',
         );
 
     test('Is supported', () async {
@@ -48,13 +48,13 @@ Future run(final DockerImage image) async {
       expect(response.starredCount, null);
       expect(response.newestItemId, isNotNull);
       expect(response.feeds, hasLength(1));
-      expect(response.feeds[0].url, 'http://localhost:${rssServer.port}/wikipedia.xml');
+      expect(response.feeds[0].url, 'http://host.docker.internal:${rssServer.port}/wikipedia.xml');
 
       response = await client.news.listFeeds();
       expect(response.starredCount, 0);
       expect(response.newestItemId, isNotNull);
       expect(response.feeds, hasLength(1));
-      expect(response.feeds[0].url, 'http://localhost:${rssServer.port}/wikipedia.xml');
+      expect(response.feeds[0].url, 'http://host.docker.internal:${rssServer.port}/wikipedia.xml');
     });
 
     test('Rename feed', () async {
@@ -247,7 +247,7 @@ Future run(final DockerImage image) async {
       expect(response.newestItemId, isNotNull);
       expect(response.feeds, hasLength(1));
       expect(response.feeds[0].folderId, 1);
-      expect(response.feeds[0].url, 'http://localhost:${rssServer.port}/wikipedia.xml');
+      expect(response.feeds[0].url, 'http://host.docker.internal:${rssServer.port}/wikipedia.xml');
     });
 
     test('Mark folder as read', () async {

--- a/tool/Dockerfile.dev
+++ b/tool/Dockerfile.dev
@@ -1,5 +1,7 @@
-FROM nextcloud:27.0.0-fpm-alpine
+FROM nextcloud:27.0.0
 WORKDIR /usr/src/nextcloud
+RUN chown -R www-data:www-data .
+USER www-data
 
 RUN ./occ maintenance:install --admin-pass admin --admin-email admin@example.com
 RUN ./occ config:system:set allow_local_remote_servers --value=true
@@ -18,5 +20,3 @@ RUN (sh /entrypoint.sh php -S 0.0.0.0:8080 &) && \
     until curl -s -o /dev/null http://localhost:8080/status.php; do true; done && \
     for user in admin user1 user2; do curl -u "$user:$user" -H "ocs-apirequest: true" -s -o /dev/null http://localhost:8080/ocs/v2.php/cloud/user; done
 COPY --chown=www-data:www-data overlay /usr/src/nextcloud/
-
-CMD ["php", "-S", "0.0.0.0:80"]

--- a/tool/dev.sh
+++ b/tool/dev.sh
@@ -5,4 +5,4 @@ cd "$(dirname "$0")/.."
 ./tool/build-dev-container.sh
 
 echo "Running development instance on http://localhost. To access it in an Android Emulator use http://10.0.2.2"
-docker run --rm -v nextcloud-neon-dev:/usr/src/nextcloud -v nextcloud-neon-dev:/var/www/html -p "80:80" --net="host" nextcloud-neon-dev
+docker run --rm -v nextcloud-neon-dev:/usr/src/nextcloud -v nextcloud-neon-dev:/var/www/html -p "80:80" --add-host=host.docker.internal:host-gateway nextcloud-neon-dev

--- a/tool/update.sh
+++ b/tool/update.sh
@@ -27,7 +27,7 @@ elif [ -d "external/nextcloud-$1" ]; then
       # shellcheck disable=SC2001
       latest_version=$(echo "$latest_tag" | sed "s/^v//")
       if [[ "$1" == "server" ]]; then
-        sed -i "s/FROM nextcloud:.*/FROM nextcloud:$latest_version-fpm-alpine/" ../../tool/Dockerfile.dev
+        sed -i "s/FROM nextcloud:.*/FROM nextcloud:$latest_version/" ../../tool/Dockerfile.dev
       else
         sed -i "s/RUN \.\/occ app:install $1 .*/RUN .\/occ app:install $1 --force --allow-unstable # $latest_version/" ../../tool/Dockerfile.dev
       fi


### PR DESCRIPTION
>  The web server runs only one single-threaded process, so PHP applications will stall if a request is blocked. 

https://www.php.net/manual/en/features.commandline.webserver.php

This makes it impossible to use with Talk. The dev container uses apache by default and tests can opt-in to use apache, but the built-in php web server is still used by default because it is a lot faster to start up.