### PR TITLE
style(neon_notes): cleanup NotesCategorySelect

### DIFF
--- a/packages/neon/neon_notes/lib/widgets/category_select.dart
+++ b/packages/neon/neon_notes/lib/widgets/category_select.dart
@@ -11,14 +11,19 @@ class NotesCategorySelect extends StatelessWidget {
     if (initialValue != null) {
       onChanged(initialValue!);
     }
+
+    categories.sort();
+
+    // After sorting the empty category '' should be at the first place
+    if (!categories.first.isNotEmpty) {
+      categories.insert(0, '');
+    }
   }
 
   final List<String> categories;
   final String? initialValue;
   final Function(String category) onChanged;
   final Function() onSubmitted;
-
-  late final _categories = categories..sort((final a, final b) => a.compareTo(b));
 
   @override
   Widget build(final BuildContext context) => Autocomplete<String>(
@@ -28,13 +33,6 @@ class NotesCategorySelect extends StatelessWidget {
               )
             : null,
         optionsBuilder: (final value) {
-          final categories = [
-            if (!_categories.contains('')) ...{
-              '',
-            },
-            ..._categories,
-          ];
-
           if (value.text.isEmpty) {
             return categories;
           }


### PR DESCRIPTION
We can omit the `compare` function when sorting as `List.sort` will default to `Comparable.compare` wich itself already is `a.combareTo(b)`

Inserting the default category should also be faster and less memory intensive now.
The only downside could be that we now insert the default category in the provided list directly. This could be a side effect to the caller of `NotesCategorySelect.new` but I'd argue that this is intended.