### PR TITLE
refactor(neon): Use image instead of bitmap library to encode bitmaps

### DIFF
--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -41,14 +41,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
-  bitmap:
-    dependency: transitive
-    description:
-      name: bitmap
-      sha256: d4ec0147d64eff00efbbeead5c04d517ea4fbb528022adaa3551e3586e80f4d4
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3"
   boolean_selector:
     dependency: transitive
     description:

--- a/packages/neon/neon/lib/src/utils/push_utils.dart
+++ b/packages/neon/neon/lib/src/utils/push_utils.dart
@@ -1,13 +1,13 @@
 import 'dart:convert';
 import 'dart:ui';
 
-import 'package:bitmap/bitmap.dart';
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_svg/flutter_svg.dart' show SvgFileLoader, vg;
+import 'package:image/image.dart' as img;
 import 'package:meta/meta.dart';
 import 'package:neon/src/blocs/accounts.dart';
 import 'package:neon/src/models/account.dart';
@@ -132,8 +132,7 @@ class PushUtils {
               final image = recorder.endRecording().toImageSync(scaledSize.width.toInt(), scaledSize.height.toInt());
               final bytes = await image.toByteData(format: ImageByteFormat.png);
 
-              final bitmap = await Bitmap.fromProvider(MemoryImage(bytes!.buffer.asUint8List()));
-              largeIconBitmap = ByteArrayAndroidBitmap(bitmap.buildHeaded());
+              largeIconBitmap = ByteArrayAndroidBitmap(img.encodeBmp(img.decodePng(bytes!.buffer.asUint8List())!));
             }
           }
         } catch (e, s) {

--- a/packages/neon/neon/pubspec.yaml
+++ b/packages/neon/neon/pubspec.yaml
@@ -7,7 +7,6 @@ environment:
   flutter: '>=3.10.4'
 
 dependencies:
-  bitmap: ^0.1.3
   collection: ^1.17.1
   crypto: ^3.0.3
   file_picker: ^5.3.0
@@ -24,6 +23,7 @@ dependencies:
   flutter_zxing: ^1.1.2 # ^1.2.0 downgrades to image ^3.0.0 which breaks our dependencies. See https://github.com/khoren93/flutter_zxing/issues/94
   go_router: ^9.0.3
   http: ^0.13.6
+  image: ^4.0.17
   intersperse: ^2.0.0
   intl: ^0.18.0
   json_annotation: ^4.8.1


### PR DESCRIPTION
The bitmap library randomly broke my build so I checked the alternatives and the image library can actually encode bitmaps. Now the encoding doesn't use any platform specific code anymore and we pull in one less dependency (at least in the app). I didn't check for performance, but it works as expected.