### PR TITLE
Cleanup/docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ For easier development we use a monorepo structure.
 This means that we have multiple packages in one git repository.
 We use [melos](https://pub.dev/packages/melos) to manage the packages in this repository.
 
-Take a look at our [melos.yaml](../melos.yaml) to find useful commands for running commands like build_runner or the analyzer in all packages.
+Take a look at our [melos.yaml](melos.yaml) to find useful commands for running commands like build_runner or the analyzer in all packages.
 
 ## Linting
 We use very strict static code analysis (also known as linting) rules.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Developing a new Nextcloud client can be as easy as adding some UI and then nece
 
 ## Contributing
 
-Checkout our [contributing docs](./docs/contributing.md) to get started with developing with Neon.
+Checkout our [contributing docs](CONTRIBUTING.md) to get started with developing with Neon.
 
 ## Development and support
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-## [Contributing](contributing.md)
+## [Contributing](../CONTRIBUTING.md)
 
 ## [Architecture overview](architecture.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # Documentation
 
+## [Code of Conduct](../CODE_OF_CONDUCT.md)
+
 ## [Contributing](../CONTRIBUTING.md)
 
 ## [Architecture overview](architecture.md)


### PR DESCRIPTION
The CoC is in the top level so I figured moving the contributing docs there makes sense. We can still list it in the ToC of the docs.