### PR TITLE
fix(dynamite): Skip comparing nullable in type results

### DIFF
--- a/packages/dynamite/dynamite/lib/src/type_result/enum.dart
+++ b/packages/dynamite/dynamite/lib/src/type_result/enum.dart
@@ -34,12 +34,8 @@ class TypeResultEnum extends TypeResult {
 
   @override
   bool operator ==(final Object other) =>
-      other is TypeResultEnum &&
-      other.className == className &&
-      other.generics == generics &&
-      other.nullable == nullable &&
-      other.subType == subType;
+      other is TypeResultEnum && other.className == className && other.generics == generics && other.subType == subType;
 
   @override
-  int get hashCode => className.hashCode + generics.hashCode + nullable.hashCode + subType.hashCode;
+  int get hashCode => className.hashCode + generics.hashCode + subType.hashCode;
 }

--- a/packages/dynamite/dynamite/lib/src/type_result/list.dart
+++ b/packages/dynamite/dynamite/lib/src/type_result/list.dart
@@ -34,12 +34,8 @@ class TypeResultList extends TypeResult {
 
   @override
   bool operator ==(final Object other) =>
-      other is TypeResultList &&
-      other.className == className &&
-      other.generics == generics &&
-      other.nullable == nullable &&
-      other.subType == subType;
+      other is TypeResultList && other.className == className && other.generics == generics && other.subType == subType;
 
   @override
-  int get hashCode => className.hashCode + generics.hashCode + nullable.hashCode + subType.hashCode;
+  int get hashCode => className.hashCode + generics.hashCode + subType.hashCode;
 }

--- a/packages/dynamite/dynamite/lib/src/type_result/map.dart
+++ b/packages/dynamite/dynamite/lib/src/type_result/map.dart
@@ -21,12 +21,8 @@ class TypeResultMap extends TypeResult {
 
   @override
   bool operator ==(final Object other) =>
-      other is TypeResultMap &&
-      other.className == className &&
-      other.generics == generics &&
-      other.nullable == nullable &&
-      other.subType == subType;
+      other is TypeResultMap && other.className == className && other.generics == generics && other.subType == subType;
 
   @override
-  int get hashCode => className.hashCode + generics.hashCode + nullable.hashCode + subType.hashCode;
+  int get hashCode => className.hashCode + generics.hashCode + subType.hashCode;
 }

--- a/packages/dynamite/dynamite/lib/src/type_result/type_result.dart
+++ b/packages/dynamite/dynamite/lib/src/type_result/type_result.dart
@@ -101,8 +101,8 @@ abstract class TypeResult {
 
   @override
   bool operator ==(final Object other) =>
-      other is TypeResult && other.className == className && other.generics == generics && other.nullable == nullable;
+      other is TypeResult && other.className == className && other.generics == generics;
 
   @override
-  int get hashCode => className.hashCode + generics.hashCode + nullable.hashCode;
+  int get hashCode => className.hashCode + generics.hashCode;
 }


### PR DESCRIPTION
In https://github.com/provokateurin/nextcloud-neon/commit/7a71e010b6fe934a92238720d9bae159570d760f the whole type was added to check if the type is already generated. This breaks https://github.com/provokateurin/nextcloud-neon/pull/465 as it has enums that are both use as nullable and non-nullable type.