### PR TITLE
fix(nextcloud,neon_files): Do not require client for toWebDavFiles

### DIFF
--- a/packages/neon/neon_files/lib/blocs/browser.dart
+++ b/packages/neon/neon_files/lib/blocs/browser.dart
@@ -56,7 +56,7 @@ class FilesBrowserBloc extends InteractiveBloc implements FilesBrowserBlocEvents
         ),
         depth: '1',
       ),
-      (final response) => response.toWebDavFiles(client.webdav).sublist(1),
+      (final response) => response.toWebDavFiles().sublist(1),
       emitEmptyCache: true,
     );
   }

--- a/packages/nextcloud/lib/src/webdav/file.dart
+++ b/packages/nextcloud/lib/src/webdav/file.dart
@@ -5,7 +5,7 @@ import 'package:nextcloud/src/webdav/webdav.dart';
 // ignore: public_member_api_docs
 extension WebDavMultistatusFile on WebDavMultistatus {
   /// Convert the [WebDavMultistatus] into a [WebDavFile] for easier handling
-  List<WebDavFile> toWebDavFiles(final WebDavClient client) => responses
+  List<WebDavFile> toWebDavFiles() => responses
       .where((final response) => response.href != null)
       .map((final response) => WebDavFile(response: response))
       .toList();

--- a/packages/nextcloud/test/webdav_test.dart
+++ b/packages/nextcloud/test/webdav_test.dart
@@ -85,7 +85,7 @@ void main() {
           ocmsharepermissions: true,
         ),
       ))
-          .toWebDavFiles(client.webdav)
+          .toWebDavFiles()
           .single;
 
       expect(response.path, '/Nextcloud.png');
@@ -150,7 +150,7 @@ void main() {
         ),
         depth: '0',
       ))
-          .toWebDavFiles(client.webdav)
+          .toWebDavFiles()
           .single;
 
       expect(response.path, '/test/');


### PR DESCRIPTION
Forgotten in https://github.com/provokateurin/nextcloud-neon/pull/520